### PR TITLE
[PDI-10610]: Updated MetaverseComponentDescriptors to latest API (get/setContext)

### DIFF
--- a/src/main/java/com/pentaho/dictionary/DictionaryConst.java
+++ b/src/main/java/com/pentaho/dictionary/DictionaryConst.java
@@ -142,7 +142,6 @@ public class DictionaryConst {
    */
   public static final String LINK_USES = "uses";
 
-
   /**
    * Label for an "writes to" edge in the graph, e.g. a table output step writes to a table
    */
@@ -344,6 +343,21 @@ public class DictionaryConst {
    * The suggested color for nodes of unknown or "other" types
    */
   public static final String COLOR_OTHER = "#ffcccc";
+
+  /**
+   * The static context refers to analysis of documents that does not produce runtime information
+   */
+  public static final String CONTEXT_STATIC = "static";
+
+  /**
+   * A runtime context refers to analyis of documents that produces runtime information (parameter values, e.g.)
+   */
+  public static final String CONTEXT_RUNTIME = "runtime";
+
+  /**
+   * The default context for metaverse descriptors
+   */
+  public static final String CONTEXT_DEFAULT = CONTEXT_STATIC;
 
   /**
    * Hides the constructor so that this class cannot be instanced

--- a/src/main/java/com/pentaho/metaverse/impl/MetaverseComponentDescriptor.java
+++ b/src/main/java/com/pentaho/metaverse/impl/MetaverseComponentDescriptor.java
@@ -1,5 +1,6 @@
 package com.pentaho.metaverse.impl;
 
+import com.pentaho.dictionary.DictionaryConst;
 import org.pentaho.platform.api.metaverse.IMetaverseComponentDescriptor;
 import org.pentaho.platform.api.metaverse.INamespace;
 
@@ -11,11 +12,20 @@ public class MetaverseComponentDescriptor implements IMetaverseComponentDescript
   private String name;
   private String type;
   private INamespace namespace;
+  private String context;
 
   public MetaverseComponentDescriptor( String name, String type, INamespace namespace ) {
     this.name = name;
     this.type = type;
     this.namespace = namespace;
+    this.context = DictionaryConst.CONTEXT_DEFAULT;
+  }
+
+  public MetaverseComponentDescriptor( String name, String type, INamespace namespace, String context ) {
+    this.name = name;
+    this.type = type;
+    this.namespace = namespace;
+    this.context = context;
   }
 
   /**
@@ -95,5 +105,25 @@ public class MetaverseComponentDescriptor implements IMetaverseComponentDescript
 
   @Override public INamespace getNamespace() {
     return namespace;
+  }
+
+  /**
+   * Gets the context ("static", "runtime", e.g.) associated with the component described by this descriptor.
+   *
+   * @return A string containing a description of the context associated with the described component
+   */
+  @Override
+  public String getContext() {
+    return context;
+  }
+
+  /**
+   * Sets the context ("static", "runtime", e.g.) associated with the component described by this descriptor.
+   *
+   * @param context the context for the described component
+   */
+  @Override
+  public void setContext( String context ) {
+    this.context = context;
   }
 }

--- a/src/main/java/com/pentaho/metaverse/impl/MetaverseDocument.java
+++ b/src/main/java/com/pentaho/metaverse/impl/MetaverseDocument.java
@@ -42,6 +42,11 @@ public class MetaverseDocument extends PropertiesHolder implements IMetaverseDoc
    */
   private INamespace namespace;
 
+  /**
+   * The context (static, runtime, e.g.) associated with this metaverse document.
+   */
+  private String context;
+
   /* (non-Javadoc)
    * @see org.pentaho.platform.api.metaverse.IMetaverseDocument#getExtension()
    */
@@ -179,5 +184,25 @@ public class MetaverseDocument extends PropertiesHolder implements IMetaverseDoc
    */
   @Override public INamespace getChildNamespace( String child, String type ) {
     return namespace.getChildNamespace( child, type );
+  }
+
+  /**
+   * Gets the context ("static", "runtime", e.g.) associated with the component described by this descriptor.
+   *
+   * @return A string containing a description of the context associated with the described component
+   */
+  @Override
+  public String getContext() {
+    return context;
+  }
+
+  /**
+   * Sets the context ("static", "runtime", e.g.) associated with the component described by this descriptor.
+   *
+   * @param context the context for the described component
+   */
+  @Override
+  public void setContext( String context ) {
+    this.context = context;
   }
 }

--- a/src/test/java/com/pentaho/metaverse/impl/MetaverseComponentDescriptorTest.java
+++ b/src/test/java/com/pentaho/metaverse/impl/MetaverseComponentDescriptorTest.java
@@ -22,6 +22,7 @@
 
 package com.pentaho.metaverse.impl;
 
+import com.pentaho.dictionary.DictionaryConst;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.metaverse.INamespace;
@@ -64,6 +65,8 @@ public class MetaverseComponentDescriptorTest {
     assertNull( descriptor.getName() );
     assertNull( descriptor.getType() );
     assertEquals( mockEmptyNamespace, descriptor.getNamespace() );
+    assertNotNull( descriptor.getContext() );
+    assertEquals( descriptor.getContext(), DictionaryConst.CONTEXT_DEFAULT );
 
     descriptor.setName( "test name" );
     assertEquals( "test name", descriptor.getName() );
@@ -73,5 +76,14 @@ public class MetaverseComponentDescriptorTest {
 
     descriptor.setNamespace( mockNamespace );
     assertEquals( "namespace-id", descriptor.getStringID() );
+
+    descriptor = new MetaverseComponentDescriptor( null, null, mockEmptyNamespace, null );
+    assertNull( descriptor.getStringID() );
+    assertNull( descriptor.getName() );
+    assertNull( descriptor.getType() );
+    assertEquals( mockEmptyNamespace, descriptor.getNamespace() );
+    assertNull( descriptor.getContext() );
+    descriptor.setContext( "test context" );
+    assertEquals( "test context", descriptor.getContext() );
   }
 }


### PR DESCRIPTION
This will allow us to reuse analyzers but have different code paths whether we're doing static or runtime analysis (for example).
