### PR TITLE
[CLEANUP] Removing the dependency for findbugs since it requires maven 3...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,11 +338,6 @@
         <version>${jxr.version}</version>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.0</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${pmd.version}</version>


### PR DESCRIPTION
.... we run maven 2 on the CI machines.
