### PR TITLE
[PDI-10610]: Added explicit Kettle deps, added exec Gremlin plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,16 +36,25 @@
         <role>developer</role>
       </roles>
     </developer>
+    <developer>
+      <name>Matt Burgess</name>
+      <email>mburgess@pentaho.com</email>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
   </developers>
 
   <properties>
     <pentaho.public.release.repo>http://nexus.pentaho.org/content/repositories/private-release/</pentaho.public.release.repo>
     <pentaho.public.snapshot.repo>http://nexus.pentaho.org/content/repositories/private-snapshot/</pentaho.public.snapshot.repo>
     <platform.plugin.name>metaverse</platform.plugin.name>
+    <pdi.plugin.name>pdi-metaverse-extensions</pdi.plugin.name>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <pentaho-platform-api.version>METAVERSE-SNAPSHOT</pentaho-platform-api.version>
     <pentaho-platform-core.version>TRUNK-SNAPSHOT</pentaho-platform-core.version>
     <pentaho-platform-repository.version>TRUNK-SNAPSHOT</pentaho-platform-repository.version>
+    <pentaho-kettle.version>TRUNK-SNAPSHOT</pentaho-kettle.version>
     <jcr.version>2.0</jcr.version>
     <spring.version>2.5.6</spring.version>
     <mockito-all.version>1.9.5</mockito-all.version>
@@ -69,6 +78,20 @@
   <dependencies>
 
     <!-- 'COMPILE' SCOPED DEPS -->
+    <dependency>
+            <groupId>pentaho-kettle</groupId>
+            <artifactId>kettle-core</artifactId>
+            <version>${pentaho-kettle.version}</version>
+            <scope>compile</scope>
+          </dependency>
+
+          <dependency>
+            <groupId>pentaho-kettle</groupId>
+            <artifactId>kettle-engine</artifactId>
+            <version>${pentaho-kettle.version}</version>
+            <scope>compile</scope>
+          </dependency>
+
     <dependency>
       <groupId>com.tinkerpop.blueprints</groupId>
       <artifactId>blueprints-core</artifactId>
@@ -329,6 +352,42 @@
           </rulesets>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.3.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.tinkerpop.gremlin</groupId>
+            <artifactId>gremlin-groovy</artifactId>
+            <version>${blueprints-core.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classpathScope>runtime</classpathScope>
+          <includeProjectDependencies>true</includeProjectDependencies>
+          <includePluginDependencies>true</includePluginDependencies>
+          <executableDependency>
+            <groupId>com.tinkerpop.gremlin</groupId>
+            <artifactId>gremlin-groovy</artifactId>
+          </executableDependency>
+          <mainClass>com.tinkerpop.gremlin.groovy.console.Console</mainClass>
+          <arguments>
+            <argument>src/it/resources/metaverse-pdi.groovy</argument>
+          </arguments>
+          <systemProperties>
+          </systemProperties>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/src/it/resources/metaverse-pdi.groovy
+++ b/src/it/resources/metaverse-pdi.groovy
@@ -1,0 +1,160 @@
+import org.pentaho.platform.api.metaverse.*
+import com.pentaho.metaverse.api.*
+import com.pentaho.metaverse.graph.*
+import com.pentaho.metaverse.impl.*
+import com.pentaho.metaverse.locator.*
+import com.pentaho.metaverse.service.*
+import com.pentaho.metaverse.analyzer.kettle.*
+import com.pentaho.metaverse.analyzer.kettle.extensionpoints.*
+import com.pentaho.metaverse.analyzer.kettle.step.*
+import com.pentaho.metaverse.analyzer.kettle.jobentry.*
+import com.pentaho.dictionary.*
+import org.pentaho.di.cluster.*
+import org.pentaho.di.core.*
+import org.pentaho.di.core.database.*
+import org.pentaho.di.core.exception.*
+import org.pentaho.di.core.extension.*
+import org.pentaho.di.core.gui.*
+import org.pentaho.di.core.logging.*
+import org.pentaho.di.core.plugins.*
+import org.pentaho.di.core.row.*
+import org.pentaho.di.core.variables.*
+import org.pentaho.di.core.vfs.*
+import org.pentaho.di.job.*
+import org.pentaho.di.repository.*
+import org.pentaho.di.trans.*
+import org.pentaho.di.trans.step.*
+import org.pentaho.di.ui.spoon.*
+import org.pentaho.di.ui.spoon.delegates.*
+import org.pentaho.di.ui.spoon.trans.*
+import org.pentaho.groovy.ui.spoon.*
+import org.pentaho.groovy.ui.spoon.repo.*
+
+i:{
+
+  try {
+    c = Class.forName('com.pentaho.metaverse.analyzer.kettle.extensionpoints.TransformationRuntimeExtensionPoint')
+    ExtensionPointPluginType.getInstance().registerCustom( c, "custom", "transRuntimeMetaverse", "TransformationStartThreads", "no description", null )
+  }
+  catch(e) {
+    println 'Extension point(s) not loaded'
+  }
+
+  PluginRegistry.addPluginType( ExtensionPointPluginType.getInstance() );
+  KettleEnvironment.init()
+  Gremlin.load()
+  mtos = [:]
+  mcs = MetaverseCompletionService.instance
+
+  trans = [] as Trans[]
+
+
+  loadIntegrationTestObjects = { obj,shell ->
+  obj.with {
+  	g = new TinkerGraph()
+  	dc = new DocumentController()
+  	mb = new MetaverseBuilder(g)
+  	dc.setMetaverseBuilder(mb)
+
+    dba = new DatabaseConnectionAnalyzer()
+    dbap = new DatabaseConnectionAnalyzerProvider()
+    dbap.setDatabaseConnectionAnalyzers([dba] as Set)
+  	tfia = new TextFileInputStepAnalyzer()
+  	tfia.setDatabaseConnectionAnalyzerProvider(dbap)
+
+  	tfoa = new TableOutputStepAnalyzer()
+  	tfoa.setDatabaseConnectionAnalyzerProvider(dbap)
+
+  	ksap = new StepAnalyzerProvider()
+  	ksap.setStepAnalyzers([tfia,tfoa] as Set)
+  	ta = new TransformationAnalyzer()
+  	ta.setStepAnalyzerProvider(ksap)
+  	ja = new JobAnalyzer()
+  	dc.setDocumentAnalyzers([ta,ja] as Set)
+  	
+    dl = new FileSystemLocator()
+  	dl.with {
+  		addDocumentListener(dc)
+  		setRepositoryId('FILE_SYSTEM_REPO')
+  		setMetaverseBuilder(dc)
+  		setRootFolder('src/it/resources/repo')
+  	}
+  	gw = new GraphMLWriter()
+  	gsonw = new GraphSONWriter()
+    g2 = new TinkerGraph()
+    gr = new GraphMLReader(g2)
+  }
+
+  shell.g = obj.g
+  shell.g2 = obj.g2
+  shell.dc = obj.dc
+  shell.mb = obj.mb
+  shell.dl = obj.dl
+  shell.ta = obj.ta
+  shell.gw = obj.gw
+  shell.gr = obj.gr
+
+  // Helper constants (to save typing)
+  shell.TRANS = DictionaryConst.NODE_TYPE_TRANS
+  shell.STEP = DictionaryConst.NODE_TYPE_TRANS_STEP
+  shell.JOB = DictionaryConst.NODE_TYPE_JOB
+  shell.JOBENTRY = DictionaryConst.NODE_TYPE_JOB_ENTRY
+}
+  getPathFormatter    = { def x = [{"${it.name} (${it.type})"}]; 10.times {x << {"<-[ ${it.label} ]-"}; x<<{"${it.name} (${it.type})"}}; x.toArray() as Closure[]}
+  getRevPathFormatter = { def x = [{"${it.name} (${it.type})"}]; 10.times {x << {"-[ ${it.label} ]->"}; x<<{"${it.name} (${it.type})"}}; x.toArray() as Closure[]}
+
+  loadIT = {
+    loadIntegrationTestObjects(mtos, this)
+    'Integration test objects loaded'
+  }
+  scanIT = {
+    dl?.startScan()
+    mcs?.waitTillEmpty()
+    'Scan complete'
+  }
+
+  loadFolder = { folder ->
+    dl.rootFolder = folder
+    ( folder as File ).eachFileMatch(groovy.io.FileType.FILES, ~/.*\.ktr/) { ktr ->
+      ktr.withInputStream { i ->
+        Variables vars = new Variables()
+        vars.setVariable( "testTransParam3", "demo" )
+        tm = new TransMeta( i, null, true, vars, null )
+        tm.filename = tm.name
+        Trans t = new Trans( tm, null, tm.name, folder, ktr.absolutePath )
+        t.setVariable( "testTransParam3", "demo" );
+        t.setVariable( "Internal.Transformation.Filename.Directory", folder);
+        tm.setVariable( "testTransParam3", "demo" );
+        tm.setVariable( "Internal.Transformation.Filename.Directory", folder);
+        trans += t
+      }
+    }
+    "loaded repo from ${folder}" 
+  }
+  loadDemo = {
+    loadFolder '../../../pentaho-metaverse-ee/src/it/resources/repo/demo'
+  }
+
+  loadRuntime = {
+    loadFolder '../../../pentaho-metaverse-ee/src/it/resources/repo/runtime'
+  }
+
+  loadGraph = { fname ->
+    new File(fname).withInputStream { i -> gr.inputGraph(i) }
+  }
+
+  // Measures the number of seconds it takes to run the given closure 
+  timeToRun = { closureToMeasure ->
+    now = System.currentTimeMillis()
+    closureToMeasure()
+    then = System.currentTimeMillis()
+    "${(then-now) / 1000.0f} s"
+  }
+
+  ls = { dir ->
+    new File(dir ?:'.').list()
+  }
+
+  loadIT()
+  'Gremlin-Kettle-Metaverse initialized successfully'
+}


### PR DESCRIPTION
This replaces the need for the GKM (Gremlin-Kettle-Metaverse) (see https://github.com/pentaho/pentaho-tackle-box/tree/master/repl/gremlin-metaverse), as it is now implemented with the Exec Maven plugin (http://mojo.codehaus.org/exec-maven-plugin).

To use, just type the following:

mvn compile exec:java

This will start the Gremlin shell with the Metaverse and PDI in the classpath, and will load the helper script (src/it/resources/metaverse-pdi.groovy).
