### PR TITLE
[BACKLOG-1792] - Organize Lineage Operations by type (Data vs Metadata)

### DIFF
--- a/src/it/java/com/pentaho/metaverse/MetaverseValidationIT.java
+++ b/src/it/java/com/pentaho/metaverse/MetaverseValidationIT.java
@@ -297,8 +297,8 @@ public class MetaverseValidationIT {
     // verify the nodes created by the step
     for ( StreamFieldNode node : selectValues.getStreamFieldNodesCreates() ) {
       // check for operations
-      if ( node.getOperations() != null ) {
-        Map<String, List<String>> ops = convertOperationsStringToMap( node.getOperations() );
+      if ( node.getMetadataOperations() != null ) {
+        Map<String, List<String>> ops = convertOperationsStringToMap( node.getMetadataOperations() );
         assertNotNull( ops );
         assertTrue( ops.size() > 0 );
       }
@@ -308,6 +308,9 @@ public class MetaverseValidationIT {
       for ( StreamFieldNode deriveNode : deriveNodes ) {
         assertNotNull( deriveNode );
       }
+
+      // there should not be any data operations on nodes touched by this step
+      assertNull( node.getDataOperations() );
     }
 
     // verify fields deleted
@@ -472,12 +475,15 @@ public class MetaverseValidationIT {
 
     ValueMapperMeta meta = (ValueMapperMeta) getStepMeta( valueMapperStepNode );
     assertEquals( meta.getFieldToUse(), usesNode.getName() );
-    Map<String, List<String>> ops = convertOperationsStringToMap( usesNode.getOperations() );
+    Map<String, List<String>> ops = convertOperationsStringToMap( usesNode.getDataOperations() );
     assertEquals( meta.getSourceValue().length, ops.get( DictionaryConst.PROPERTY_TRANSFORMS ).size() );
     assertEquals( meta.getTargetValue().length, ops.get( DictionaryConst.PROPERTY_TRANSFORMS ).size() );
 
     int derivedCount = getIterableSize( usesNode.getFieldNodesDerivedFromMe() );
     assertEquals( 0, derivedCount );
+
+    // there should not be any metadata operations
+    assertNull( usesNode.getMetadataOperations() );
   }
 
   @Test
@@ -503,7 +509,7 @@ public class MetaverseValidationIT {
     ValueMapperMeta meta = (ValueMapperMeta) getStepMeta( valueMapperStepNode );
     assertEquals( meta.getFieldToUse(), usesNode.getName() );
     assertEquals( meta.getTargetField(), createsNode.getName() );
-    assertNull( usesNode.getOperations() );
+    assertNull( usesNode.getMetadataOperations() );
 
     int derivesCount = getIterableSize( createsNode.getFieldNodesThatDeriveMe() );
     assertEquals( 1, derivesCount );
@@ -513,10 +519,13 @@ public class MetaverseValidationIT {
       assertEquals( usesNode.getType(), derives.getType() );
     }
 
-    Map<String, List<String>> ops = convertOperationsStringToMap( createsNode.getOperations() );
+    Map<String, List<String>> ops = convertOperationsStringToMap( createsNode.getDataOperations() );
+
     assertEquals( meta.getSourceValue().length, ops.get( DictionaryConst.PROPERTY_TRANSFORMS ).size() );
     assertEquals( meta.getTargetValue().length, ops.get( DictionaryConst.PROPERTY_TRANSFORMS ).size() );
 
+    // there should not be any metadata operations
+    assertNull( createsNode.getMetadataOperations() );
   }
 
   @Test

--- a/src/it/java/com/pentaho/metaverse/frames/FieldNode.java
+++ b/src/it/java/com/pentaho/metaverse/frames/FieldNode.java
@@ -35,7 +35,10 @@ public interface FieldNode extends Concept {
   public String getKettleType();
 
   @Property( DictionaryConst.PROPERTY_OPERATIONS )
-  public String getOperations();
+  public String getMetadataOperations();
+
+  @Property( DictionaryConst.PROPERTY_DATA_OPERATIONS )
+  public String getDataOperations();
 
   @Adjacency( label = "uses", direction = Direction.IN )
   public Iterable<TransformationStepNode> getStepsThatUseMe();

--- a/src/main/java/com/pentaho/dictionary/DictionaryConst.java
+++ b/src/main/java/com/pentaho/dictionary/DictionaryConst.java
@@ -94,9 +94,14 @@ public class DictionaryConst {
   public static final String PROPERTY_STATUS = "status";
 
   /**
-   * Property key for "operations"
+   * Property key for "metadataOperations"
    */
-  public static final String PROPERTY_OPERATIONS = "operations";
+  public static final String PROPERTY_OPERATIONS = "metadataOperations";
+
+  /**
+   * Property key for "dataOperations"
+   */
+  public static final String PROPERTY_DATA_OPERATIONS = "dataOperations";
 
   /**
    * Property key for "transforms"

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/ChangeType.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/ChangeType.java
@@ -1,0 +1,42 @@
+/*
+ * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2002 - 2015 Pentaho Corporation (Pentaho). All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Pentaho and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Pentaho is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Pentaho,
+ * explicitly covering such access.
+ */
+
+package com.pentaho.metaverse.analyzer.kettle;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ChangeType {
+  METADATA( "metadata" ),
+  DATA( "data" );
+
+  private final String name;
+
+  private ChangeType( String name ) {
+    this.name = name;
+  }
+
+  @JsonValue
+  public String toString() {
+    return name;
+  }
+
+}

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/ComponentDerivationRecord.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/ComponentDerivationRecord.java
@@ -19,23 +19,42 @@ public class ComponentDerivationRecord {
 
   protected String changedEntityName;
   protected String originalEntityName;
+  protected ChangeType changeType;
 
   protected Map<String, List<String>> operations;
 
   public ComponentDerivationRecord() {
+    changeType = ChangeType.METADATA;
     operations = new HashMap<String, List<String>>();
   }
 
   public ComponentDerivationRecord( String originalEntityName, String changedEntityName ) {
+    this( originalEntityName, changedEntityName, ChangeType.METADATA );
+  }
+
+  public ComponentDerivationRecord( String originalEntityName, String changedEntityName, ChangeType changeType ) {
     this();
     this.changedEntityName = changedEntityName;
     this.originalEntityName = originalEntityName;
+    this.changeType = changeType;
   }
 
-  public ComponentDerivationRecord( String changedEntityName ) {
+  public ComponentDerivationRecord( String changedEntityName, ChangeType changeType ) {
     this();
     this.changedEntityName = changedEntityName;
     this.originalEntityName = changedEntityName;
+    this.changeType = changeType;
+  }
+  public ComponentDerivationRecord( String changedEntityName ) {
+    this( changedEntityName, ChangeType.METADATA );
+  }
+
+  public ChangeType getChangeType() {
+    return changeType;
+  }
+
+  public void setChangeType( ChangeType changeType ) {
+    this.changeType = changeType;
   }
 
   public String getChangedEntityName() {

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/BaseStepAnalyzer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/BaseStepAnalyzer.java
@@ -24,6 +24,7 @@ package com.pentaho.metaverse.analyzer.kettle.step;
 
 import com.pentaho.dictionary.DictionaryConst;
 import com.pentaho.metaverse.analyzer.kettle.BaseKettleMetaverseComponentWithDatabases;
+import com.pentaho.metaverse.analyzer.kettle.ChangeType;
 import com.pentaho.metaverse.analyzer.kettle.ComponentDerivationRecord;
 import com.pentaho.metaverse.analyzer.kettle.IDatabaseConnectionAnalyzer;
 import com.pentaho.metaverse.api.model.kettle.IFieldMapping;
@@ -355,7 +356,18 @@ public abstract class BaseStepAnalyzer<T extends BaseStepMeta>
         new Namespace( rootNode.getLogicalId() ),
         descriptor.getContext() );
       newFieldNode = createNodeFromDescriptor( newFieldDescriptor );
-      newFieldNode.setProperty( DictionaryConst.PROPERTY_OPERATIONS, changeRecord.toString() );
+      final String changePropertyType;
+      ChangeType changeType = changeRecord.getChangeType();
+      switch( changeType ) {
+        case DATA:
+          changePropertyType = DictionaryConst.PROPERTY_DATA_OPERATIONS;
+          break;
+        case METADATA:
+        default:
+          changePropertyType = DictionaryConst.PROPERTY_OPERATIONS;
+          break;
+      }
+      newFieldNode.setProperty( changePropertyType, changeRecord.toString() );
       metaverseBuilder.addLink( fieldNode, DictionaryConst.LINK_DERIVES, newFieldNode );
     }
     return newFieldNode;

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/selectvalues/SelectValuesStepAnalyzer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/selectvalues/SelectValuesStepAnalyzer.java
@@ -23,6 +23,7 @@
 package com.pentaho.metaverse.analyzer.kettle.step.selectvalues;
 
 import com.pentaho.dictionary.DictionaryConst;
+import com.pentaho.metaverse.analyzer.kettle.ChangeType;
 import com.pentaho.metaverse.analyzer.kettle.ComponentDerivationRecord;
 import com.pentaho.metaverse.analyzer.kettle.step.BaseStepAnalyzer;
 import com.pentaho.metaverse.api.model.kettle.IFieldMapping;
@@ -121,7 +122,7 @@ public class SelectValuesStepAnalyzer extends BaseStepAnalyzer<SelectValuesMeta>
         outputFieldName = fieldRenames[ i ];
 
         changeRecord = new ComponentDerivationRecord( inputFieldName,
-            outputFieldName == null ? inputFieldName : outputFieldName );
+            outputFieldName == null ? inputFieldName : outputFieldName, ChangeType.METADATA );
 
         // NOTE: We use equalsIgnoreCase instead of equals because that's how Select Values currently works
         if ( inputFieldName != null && outputFieldName != null && !inputFieldName
@@ -154,7 +155,7 @@ public class SelectValuesStepAnalyzer extends BaseStepAnalyzer<SelectValuesMeta>
           outputFieldName = metadataChange.getRename();
 
           changeRecord = new ComponentDerivationRecord( inputFieldName,
-              outputFieldName == null ? inputFieldName : outputFieldName );
+              outputFieldName == null ? inputFieldName : outputFieldName, ChangeType.METADATA );
 
           // NOTE: We use equalsIgnoreCase instead of equals because that's how Select Values currently works
           if ( inputFieldName != null && outputFieldName != null && !inputFieldName

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzer.java
@@ -22,9 +22,13 @@
 
 package com.pentaho.metaverse.analyzer.kettle.step.valuemapper;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.pentaho.dictionary.DictionaryConst;
+import com.pentaho.metaverse.analyzer.kettle.ChangeType;
+import com.pentaho.metaverse.analyzer.kettle.ComponentDerivationRecord;
+import com.pentaho.metaverse.analyzer.kettle.step.BaseStepAnalyzer;
+import com.pentaho.metaverse.api.model.kettle.IFieldMapping;
+import com.pentaho.metaverse.impl.MetaverseComponentDescriptor;
+import com.pentaho.metaverse.impl.model.kettle.FieldMapping;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -33,15 +37,13 @@ import org.pentaho.platform.api.metaverse.IComponentDescriptor;
 import org.pentaho.platform.api.metaverse.IMetaverseNode;
 import org.pentaho.platform.api.metaverse.MetaverseAnalyzerException;
 
-import com.pentaho.dictionary.DictionaryConst;
-import com.pentaho.metaverse.analyzer.kettle.ComponentDerivationRecord;
-import com.pentaho.metaverse.analyzer.kettle.step.BaseStepAnalyzer;
-import com.pentaho.metaverse.api.model.kettle.IFieldMapping;
-import com.pentaho.metaverse.impl.MetaverseComponentDescriptor;
-import com.pentaho.metaverse.impl.model.kettle.FieldMapping;
+import java.util.HashSet;
+import java.util.Set;
+
 
 /**
- * User: RFellows Date: 9/16/14
+ * The ValueMapperStepAnalyzer is responsible for providing nodes and links (i.e. relationships) between for the fields
+ * operated on by Value Mapper steps.
  */
 public class ValueMapperStepAnalyzer extends BaseStepAnalyzer<ValueMapperMeta> {
 
@@ -71,7 +73,7 @@ public class ValueMapperStepAnalyzer extends BaseStepAnalyzer<ValueMapperMeta> {
     // if no target field specified
     if ( overwritesSourceField ) {
       // add some data operation property to the source node
-      sourceFieldNode.setProperty( DictionaryConst.PROPERTY_OPERATIONS, changeRecord.toString() );
+      sourceFieldNode.setProperty( DictionaryConst.PROPERTY_DATA_OPERATIONS, changeRecord.toString() );
       metaverseBuilder.updateNode( sourceFieldNode );
     } else {
       final IComponentDescriptor desc = new MetaverseComponentDescriptor( targetField,
@@ -93,7 +95,8 @@ public class ValueMapperStepAnalyzer extends BaseStepAnalyzer<ValueMapperMeta> {
   protected ComponentDerivationRecord buildChangeRecord(
       final String fieldName, final String[] sourceValues, final String[] targetValues ) {
 
-    final ComponentDerivationRecord changeRecord = new ComponentDerivationRecord( fieldName );
+    final ComponentDerivationRecord changeRecord = new ComponentDerivationRecord( fieldName, ChangeType.DATA );
+
     for ( int i = 0; i < sourceValues.length; i++ ) {
       changeRecord.addOperand( DictionaryConst.PROPERTY_TRANSFORMS, sourceValues[i] + " -> " + targetValues[i] );
     }

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/ComponentDerivationRecordTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/ComponentDerivationRecordTest.java
@@ -21,13 +21,16 @@ public class ComponentDerivationRecordTest {
   @Test
   public void testNonDefaultConstructor() {
     record = new ComponentDerivationRecord( "originalRecord", "myRecord" );
+    assertEquals( ChangeType.METADATA, record.getChangeType() );
+
+    record.setChangeType( ChangeType.DATA );
+    assertEquals( ChangeType.DATA, record.getChangeType() );
   }
 
   @Test
   public void testGetEntityName() throws Exception {
     assertEquals( "myRecord", record.getChangedEntityName() );
     assertNull( new ComponentDerivationRecord().getChangedEntityName() );
-
   }
 
   @Test

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzerTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzerTest.java
@@ -27,7 +27,6 @@ import com.pentaho.metaverse.api.model.kettle.IFieldMapping;
 import com.pentaho.metaverse.impl.MetaverseComponentDescriptor;
 import com.pentaho.metaverse.impl.model.kettle.FieldMapping;
 import com.pentaho.metaverse.testutils.MetaverseTestUtils;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,8 +43,8 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.valuemapper.ValueMapperMeta;
-import org.pentaho.platform.api.metaverse.IMetaverseBuilder;
 import org.pentaho.platform.api.metaverse.IComponentDescriptor;
+import org.pentaho.platform.api.metaverse.IMetaverseBuilder;
 import org.pentaho.platform.api.metaverse.IMetaverseNode;
 import org.pentaho.platform.api.metaverse.IMetaverseObjectFactory;
 import org.pentaho.platform.api.metaverse.INamespace;


### PR DESCRIPTION
[BACKLOG-1792] - Organize Lineage Operations by type (Data vs Metadata)
- Split the original "operations" node property into metadataOperations and dataOperations.
- Added ChangeType enum
- Added ChangeType member field to ComponentDerivationRecord to indicate if it is a data or metadata change.
- Updated the ValueMapperStepAnalyzer to create "data" changes
- Updated the SelectValuesStepAnalyzer to create "metadata" changes
- Updated BaseStepAnalyzer.processFieldChangeRecord to set the correct property (dataOperations or metadataOperations) based on the ChangeType of the ComponentDerivationRecord.
- Updated the validation integration tests to account for the split
