### PR TITLE
[BACKLOG-1801]: Fixed bug in trans runtime extension point for repo-based transformations

### DIFF
--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
@@ -106,10 +106,14 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
 
     String filename = trans.getFilename();
 
+    if ( filename == null ) {
+      filename = transMeta.getPathAndName();
+    }
+
     String filePath = null;
     try {
       filePath = new File( filename ).getCanonicalPath();
-    } catch ( IOException e ) {
+    } catch ( Exception e ) {
       // TODO ?
     }
 


### PR DESCRIPTION
Repo-based transformations return null for getFilename(), I changed it to use getPathAndName in that case.
