### PR TITLE
[BACKLOG-1801]: Fix client-tool node in design-time metaverse, add test script

### DIFF
--- a/src/it/resources/lineage_graph_at_design.groovy
+++ b/src/it/resources/lineage_graph_at_design.groovy
@@ -1,0 +1,28 @@
+import org.pentaho.di.core.extension.*
+
+metaversePlugin = plugins.findPluginWithId(ExtensionPointPluginType, 'transChangeLineageGraph')
+
+// The lineage graph map (and all metaverse stuff) is in different plugin(s) than the GroovyConsole
+cl = plugins.getClassLoader(metaversePlugin)
+Thread.currentThread().setContextClassLoader(cl)
+LineageGraphMap = cl.loadClass('com.pentaho.metaverse.graph.LineageGraphMap')
+Direction = cl.loadClass('com.tinkerpop.blueprints.Direction')
+GraphMLWriter = cl.loadClass('com.pentaho.metaverse.graph.GraphMLWriter')
+
+transAnalysis = LineageGraphMap.getInstance().get( activeTrans );
+try {
+  graph = transAnalysis.get();
+  graph.vertices.each { v ->
+    println( "Found node: ${v.getProperty('name')} (${v.getProperty('type') ?: ''}${v.getProperty('virtual') ? 'VIRTUAL' : ''})" );
+  }
+  println
+  graph.edges.each { e ->
+    inV = e.getVertex(Direction.IN).getProperty('name')
+    outV = e.getVertex(Direction.OUT)?.getProperty('name')
+    println( "Found edge: $outV -[ $e.label ]-> $inV" );
+  }
+} catch ( Exception e ) {
+  println( "error during analysis", e );
+}
+//GraphMLWriter.newInstance().outputGraph(graph, new FileOutputStream('/Users/mburgess/xpt_test.graphml') )
+true

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtil.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtil.java
@@ -21,6 +21,7 @@
  */
 package com.pentaho.metaverse.analyzer.kettle.extensionpoints.trans;
 
+import com.pentaho.dictionary.DictionaryConst;
 import com.pentaho.metaverse.impl.MetaverseBuilder;
 import com.pentaho.metaverse.impl.Namespace;
 import com.pentaho.metaverse.messages.Messages;
@@ -31,6 +32,8 @@ import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.platform.api.metaverse.IDocument;
 import org.pentaho.platform.api.metaverse.IMetaverseBuilder;
+import org.pentaho.platform.api.metaverse.IMetaverseNode;
+import org.pentaho.platform.api.metaverse.IMetaverseObjectFactory;
 import org.pentaho.platform.api.metaverse.INamespace;
 import org.pentaho.platform.api.metaverse.MetaverseException;
 
@@ -47,14 +50,21 @@ public class TransExtensionPointUtil {
       throw new MetaverseException( Messages.getString( "ERROR.Document.IsNull" ) );
     }
 
-    final INamespace namespace = new Namespace( KettleClientEnvironment.getInstance().getClient().toString() );
-
     final Graph graph = new TinkerGraph();
     final IMetaverseBuilder metaverseBuilder = new MetaverseBuilder( graph );
+    final IMetaverseObjectFactory objFactory = metaverseBuilder.getMetaverseObjectFactory();
+
+    // Add the client design node
+    final String clientName = KettleClientEnvironment.getInstance().getClient().toString();
+    final INamespace namespace = new Namespace( clientName );
+
+    final IMetaverseNode designNode =
+      objFactory.createNodeObject( clientName, clientName, DictionaryConst.NODE_TYPE_LOCATOR );
+    metaverseBuilder.addNode( designNode );
 
     // Create a document object containing the transMeta
     final IDocument document = MetaverseUtil.createDocument(
-      metaverseBuilder.getMetaverseObjectFactory(),
+      objFactory,
       namespace,
       transMeta,
       transMeta.getFilename(),


### PR DESCRIPTION
The added Groovy file can be run from PDI if you download my Groovy Console Spoon plugin from the PDI Marketplace. It will fetch the graph for the current (active) Trans and print the nodes and edges. You can uncomment the line at the end to get a GraphML output file that can be opened in yEd. 

I used this to find the issue with a null virtual node hanging around, turns out the design node with ID set to the client (SPOON, e.g.) was being created twice. The code fix is to unify those to a single node (which is like a locator node in the original metaverse, and its type is "Locator" for reuse of query code).
