### PR TITLE
[BACKLOG-533]: Refactor resource consumers to get the step; fix TextFileOutput

### DIFF
--- a/src/it/java/com/pentaho/metaverse/MetaverseValidationIT.java
+++ b/src/it/java/com/pentaho/metaverse/MetaverseValidationIT.java
@@ -552,7 +552,7 @@ public class MetaverseValidationIT {
     Iterable<StreamFieldNode> usedFields = textFileOutputStepNode.getStreamFieldNodesUses();
     int usedFieldCount = getIterableSize( usedFields );
     assertEquals( outputFields.length, usedFieldCount );
-    assertEquals( incomingFields.size(), usedFieldCount );
+    assertEquals( incomingFields.size()-1, usedFieldCount );
 
     for ( StreamFieldNode usedField : usedFields ) {
       ValueMetaInterface vmi = incomingFields.searchValueMeta( usedField.getName() );

--- a/src/it/resources/repo/validation/textFileOutput.ktr
+++ b/src/it/resources/repo/validation/textFileOutput.ktr
@@ -74,9 +74,68 @@
   </notepads>
   <order>
   <hop> <from>Data Grid</from><to>Text file output</to><enabled>Y</enabled> </hop>
-  <hop> <from>Data Grid</from><to>WriteToThisFile</to><enabled>Y</enabled> </hop>
-  <hop> <from>WriteToThisFile</from><to>Text file output - file from field</to><enabled>Y</enabled> </hop>
+  <hop> <from>Data Grid</from><to>Text file output - file from field</to><enabled>Y</enabled> </hop>
   </order>
+  <step>
+    <name>Data Grid</name>
+    <type>DataGrid</type>
+    <description/>
+    <distribute>N</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+         <partitioning>
+           <method>none</method>
+           <schema_name/>
+           </partitioning>
+    <fields>
+      <field>
+        <name>City</name>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>70</length>
+        <precision>-1</precision>
+        <set_empty_string>N</set_empty_string>
+      </field>
+      <field>
+        <name>State</name>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>2</length>
+        <precision>-1</precision>
+        <set_empty_string>N</set_empty_string>
+      </field>
+      <field>
+        <name>file</name>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>-1</length>
+        <precision>-1</precision>
+        <set_empty_string>N</set_empty_string>
+      </field>
+    </fields>
+    <data>
+      <line> <item>Orlando</item><item>FL</item><item>textFileOutputTest</item> </line>
+      <line> <item>Miami</item><item>FL</item><item>textFileOutputTest</item> </line>
+      <line> <item>Jacksonville</item><item>FL</item><item>textFileOutputTest</item> </line>
+      <line> <item>New York</item><item>NY</item><item>textFileOutputTest</item> </line>
+    </data>
+     <cluster_schema/>
+ <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
+      <xloc>127</xloc>
+      <yloc>148</yloc>
+      <draw>Y</draw>
+      </GUI>
+    </step>
+
   <step>
     <name>Text file output</name>
     <type>TextFileOutput</type>
@@ -94,7 +153,7 @@
     <enclosure_fix_disabled>N</enclosure_fix_disabled>
     <header>Y</header>
     <footer>N</footer>
-    <format>DOS</format>
+    <format>UNIX</format>
     <compression>None</compression>
     <encoding/>
     <endedLine/>
@@ -147,92 +206,8 @@
     </fields>
      <cluster_schema/>
  <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>361</xloc>
-      <yloc>148</yloc>
-      <draw>Y</draw>
-      </GUI>
-    </step>
-
-  <step>
-    <name>Data Grid</name>
-    <type>DataGrid</type>
-    <description/>
-    <distribute>N</distribute>
-    <custom_distribution/>
-    <copies>1</copies>
-         <partitioning>
-           <method>none</method>
-           <schema_name/>
-           </partitioning>
-    <fields>
-      <field>
-        <name>City</name>
-        <type>String</type>
-        <format/>
-        <currency/>
-        <decimal/>
-        <group/>
-        <length>70</length>
-        <precision>-1</precision>
-        <set_empty_string>N</set_empty_string>
-      </field>
-      <field>
-        <name>State</name>
-        <type>String</type>
-        <format/>
-        <currency/>
-        <decimal/>
-        <group/>
-        <length>2</length>
-        <precision>-1</precision>
-        <set_empty_string>N</set_empty_string>
-      </field>
-    </fields>
-    <data>
-      <line> <item>Orlando</item><item>FL</item> </line>
-      <line> <item>Miami</item><item>FL</item> </line>
-      <line> <item>Jacksonville</item><item>FL</item> </line>
-      <line> <item>New York</item><item>NY</item> </line>
-    </data>
-     <cluster_schema/>
- <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>127</xloc>
-      <yloc>148</yloc>
-      <draw>Y</draw>
-      </GUI>
-    </step>
-
-  <step>
-    <name>WriteToThisFile</name>
-    <type>DataGrid</type>
-    <description/>
-    <distribute>Y</distribute>
-    <custom_distribution/>
-    <copies>1</copies>
-         <partitioning>
-           <method>none</method>
-           <schema_name/>
-           </partitioning>
-    <fields>
-      <field>
-        <name>file</name>
-        <type>String</type>
-        <format/>
-        <currency/>
-        <decimal/>
-        <group/>
-        <length>500</length>
-        <precision>-1</precision>
-        <set_empty_string>N</set_empty_string>
-      </field>
-    </fields>
-    <data>
-      <line> <item/> </line>
-    </data>
-     <cluster_schema/>
- <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>233</xloc>
-      <yloc>257</yloc>
+      <xloc>247</xloc>
+      <yloc>82</yloc>
       <draw>Y</draw>
       </GUI>
     </step>
@@ -254,7 +229,7 @@
     <enclosure_fix_disabled>N</enclosure_fix_disabled>
     <header>Y</header>
     <footer>N</footer>
-    <format>DOS</format>
+    <format>UNIX</format>
     <compression>None</compression>
     <encoding/>
     <endedLine/>
@@ -267,7 +242,7 @@
       <servlet_output>N</servlet_output>
       <do_not_open_new_file_init>Y</do_not_open_new_file_init>
       <extention>txt</extention>
-      <append>N</append>
+      <append>Y</append>
       <split>N</split>
       <haspartno>N</haspartno>
       <add_date>N</add_date>
@@ -307,8 +282,8 @@
     </fields>
      <cluster_schema/>
  <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>395</xloc>
-      <yloc>257</yloc>
+      <xloc>248</xloc>
+      <yloc>222</yloc>
       <draw>Y</draw>
       </GUI>
     </step>

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/IExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/IExternalResourceConsumer.java
@@ -22,7 +22,6 @@
 package com.pentaho.metaverse.analyzer.kettle.extensionpoints;
 
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
-import org.pentaho.di.core.row.RowMetaInterface;
 
 import java.util.Collection;
 
@@ -35,7 +34,4 @@ public interface IExternalResourceConsumer<T> extends MetaClassProvider<T>, Clon
   boolean isDataDriven( T consumer );
 
   Collection<IExternalResourceInfo> getResourcesFromMeta( T consumer );
-
-  Collection<IExternalResourceInfo> getResourcesFromRow( T consumer, RowMetaInterface rowMeta, Object[] row );
-
 }

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/IStepExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/IStepExternalResourceConsumer.java
@@ -21,14 +21,21 @@
  */
 package com.pentaho.metaverse.analyzer.kettle.extensionpoints;
 
+import com.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.BaseStepMeta;
+
+import java.util.Collection;
 
 /**
  * IStepExternalResourceConsumer is a helper interface used by ExternalResourceConsumer plugins that handle a single
  * PDI step type (see the parameterized type in declaration)
  *
- * @param <T> The type of step that will consume external resources
+ * @param <M> The type of step that will consume external resources
  */
-public interface IStepExternalResourceConsumer<T extends BaseStepMeta>
-  extends IExternalResourceConsumer<T> {
+public interface IStepExternalResourceConsumer<S extends BaseStep, M extends BaseStepMeta>
+  extends IExternalResourceConsumer<M> {
+
+  Collection<IExternalResourceInfo> getResourcesFromRow( S consumer, RowMetaInterface rowMeta, Object[] row );
 }

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/BaseJobEntryExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/BaseJobEntryExternalResourceConsumer.java
@@ -23,7 +23,6 @@ package com.pentaho.metaverse.analyzer.kettle.extensionpoints.job.entry;
 
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.IJobEntryExternalResourceConsumer;
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
-import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.job.entry.JobEntryBase;
 
 import java.util.Collection;
@@ -46,8 +45,4 @@ public abstract class BaseJobEntryExternalResourceConsumer<T extends JobEntryBas
     return Collections.emptyList();
   }
 
-  @Override
-  public Collection<IExternalResourceInfo> getResourcesFromRow( T meta, RowMetaInterface rowMeta, Object[] row ) {
-    return Collections.emptyList();
-  }
 }

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/BaseStepExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/BaseStepExternalResourceConsumer.java
@@ -24,6 +24,7 @@ package com.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.step;
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.IStepExternalResourceConsumer;
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.BaseStepMeta;
 
 import java.util.Collection;
@@ -33,21 +34,21 @@ import java.util.Collections;
  * This class is a do-nothing reference implementation for StepExternalConsumer plugins. Subclasses should override
  * the various methods with business logic that can handle the external resources used by the given step.
  */
-public abstract class BaseStepExternalResourceConsumer<T extends BaseStepMeta>
-  implements IStepExternalResourceConsumer<T> {
+public abstract class BaseStepExternalResourceConsumer<S extends BaseStep, M extends BaseStepMeta>
+  implements IStepExternalResourceConsumer<S, M> {
 
   @Override
-  public boolean isDataDriven( T meta ) {
+  public boolean isDataDriven( M meta ) {
     return false;
   }
 
   @Override
-  public Collection<IExternalResourceInfo> getResourcesFromMeta( T meta ) {
+  public Collection<IExternalResourceInfo> getResourcesFromMeta( M meta ) {
     return Collections.emptyList();
   }
 
   @Override
-  public Collection<IExternalResourceInfo> getResourcesFromRow( T meta, RowMetaInterface rowMeta, Object[] row ) {
+  public Collection<IExternalResourceInfo> getResourcesFromRow( S step, RowMetaInterface rowMeta, Object[] row ) {
     return Collections.emptyList();
   }
 }

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListener.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListener.java
@@ -28,6 +28,7 @@ import com.pentaho.metaverse.api.model.IExecutionProfile;
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.RowAdapter;
 import org.pentaho.di.trans.step.StepInterface;
 
@@ -56,10 +57,11 @@ public class StepExternalConsumerRowListener extends RowAdapter {
    * Object[])
    */
   @Override
+  @SuppressWarnings( "unchecked" )
   public void rowReadEvent( RowMetaInterface rowMeta, Object[] row ) throws KettleStepException {
 
     Collection<IExternalResourceInfo> resources =
-      stepExternalResourceConsumer.getResourcesFromRow( step.getStepMeta().getStepMetaInterface(), rowMeta, row );
+      stepExternalResourceConsumer.getResourcesFromRow( (BaseStep) step, rowMeta, row );
     if ( resources != null ) {
       // Add the resources to the execution profile
       IExecutionProfile executionProfile = TransformationRuntimeExtensionPoint.getProfileMap().get( step.getTrans() );

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputExternalResourceConsumer.java
@@ -31,6 +31,7 @@ import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.csvinput.CsvInput;
 import org.pentaho.di.trans.steps.csvinput.CsvInputMeta;
 
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ import java.util.Collections;
   id = "CsvFileInputExternalResourceConsumer",
   name = "CsvFileInputExternalResourceConsumer"
 )
-public class CsvFileInputExternalResourceConsumer extends BaseStepExternalResourceConsumer<CsvInputMeta> {
+public class CsvFileInputExternalResourceConsumer extends BaseStepExternalResourceConsumer<CsvInput, CsvInputMeta> {
 
   @Override
   public boolean isDataDriven( CsvInputMeta meta ) {

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputExternalResourceConsumer.java
@@ -27,6 +27,7 @@ import com.pentaho.metaverse.analyzer.kettle.plugin.ExternalResourceConsumer;
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
 import com.pentaho.metaverse.impl.model.ExternalResourceInfoFactory;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.trans.steps.tableoutput.TableOutput;
 import org.pentaho.di.trans.steps.tableoutput.TableOutputMeta;
 
 import java.util.Collection;
@@ -38,7 +39,8 @@ import java.util.Set;
   id = "TableOutputExternalResourceConsumer",
   name = "TableOutputExternalResourceConsumer"
 )
-public class TableOutputExternalResourceConsumer extends BaseStepExternalResourceConsumer<TableOutputMeta> {
+public class TableOutputExternalResourceConsumer
+  extends BaseStepExternalResourceConsumer<TableOutput, TableOutputMeta> {
   @Override
   public Class<TableOutputMeta> getMetaClass() {
     return TableOutputMeta.class;

--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputExternalResourceConsumer.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputExternalResourceConsumer.java
@@ -34,6 +34,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.textfileinput.TextFileInput;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputMeta;
 
 import java.util.ArrayList;
@@ -45,7 +46,8 @@ import java.util.LinkedList;
   id = "TextFileInputExternalResourceConsumer",
   name = "TextFileInputExternalResourceConsumer"
 )
-public class TextFileInputExternalResourceConsumer extends BaseStepExternalResourceConsumer<TextFileInputMeta> {
+public class TextFileInputExternalResourceConsumer
+  extends BaseStepExternalResourceConsumer<TextFileInput, TextFileInputMeta> {
 
   @Override
   public boolean isDataDriven( TextFileInputMeta meta ) {
@@ -93,8 +95,9 @@ public class TextFileInputExternalResourceConsumer extends BaseStepExternalResou
 
   @Override
   public Collection<IExternalResourceInfo> getResourcesFromRow(
-    TextFileInputMeta meta, RowMetaInterface rowMeta, Object[] row ) {
+    TextFileInput textFileInput, RowMetaInterface rowMeta, Object[] row ) {
     Collection<IExternalResourceInfo> resources = new LinkedList<IExternalResourceInfo>();
+    TextFileInputMeta meta = (TextFileInputMeta) textFileInput.getStepMetaInterface();
 
     try {
       String filename = rowMeta.getString( row, meta.getAcceptingField(), null );

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/JobEntryExternalResourceConsumerStub.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/JobEntryExternalResourceConsumerStub.java
@@ -22,12 +22,6 @@ public class JobEntryExternalResourceConsumerStub implements IJobEntryExternalRe
   }
 
   @Override
-  public Collection<IExternalResourceInfo> getResourcesFromRow(
-    Object meta, RowMetaInterface rowMeta, Object[] row ) {
-    return null;
-  }
-
-  @Override
   public Class<?> getMetaClass() {
     return JobEntryBase.class;
   }

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/StepExternalResourceConsumerStub.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/StepExternalResourceConsumerStub.java
@@ -23,6 +23,7 @@ package com.pentaho.metaverse.analyzer.kettle.extensionpoints;
 
 import com.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.BaseStepMeta;
 
 import java.util.Collection;
@@ -43,13 +44,14 @@ public class StepExternalResourceConsumerStub implements IStepExternalResourceCo
   }
 
   @Override
-  public Collection<IExternalResourceInfo> getResourcesFromRow(
-    Object meta, RowMetaInterface rowMeta, Object[] row ) {
-    return null;
+  public Class<?> getMetaClass() {
+    return BaseStepMeta.class;
   }
 
   @Override
-  public Class<?> getMetaClass() {
-    return BaseStepMeta.class;
+  public Collection<IExternalResourceInfo> getResourcesFromRow(
+    BaseStep consumer, RowMetaInterface rowMeta, Object[] row ) {
+
+    return null;
   }
 }

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/BaseJobEntryExternalResourceConsumerTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/BaseJobEntryExternalResourceConsumerTest.java
@@ -34,10 +34,4 @@ public class BaseJobEntryExternalResourceConsumerTest {
     assertTrue( resources.isEmpty() );
   }
 
-  @Test
-  public void testGetResourcesFromRow() throws Exception {
-    Collection<IExternalResourceConsumer> resources = consumer.getResourcesFromRow( null, null, null );
-    assertNotNull( resources );
-    assertTrue( resources.isEmpty() );
-  }
 }

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListenerTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListenerTest.java
@@ -28,6 +28,7 @@ import com.pentaho.metaverse.api.model.IExecutionProfile;
 import org.junit.Test;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
@@ -42,7 +43,7 @@ public class StepExternalConsumerRowListenerTest {
   @Test
   public void testStepExternalConsumerRowListener() throws Exception {
     IStepExternalResourceConsumer consumer = mock( IStepExternalResourceConsumer.class );
-    StepInterface mockStep = mock( StepInterface.class );
+    BaseStep mockStep = mock( BaseStep.class, withSettings().extraInterfaces( StepInterface.class ) );
     StepMeta mockStepMeta = mock( StepMeta.class );
     BaseStepMeta bsm = mock( BaseStepMeta.class, withSettings().extraInterfaces( StepMetaInterface.class ) );
     StepMetaInterface stepMetaInterface = (StepMetaInterface) bsm;

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputStepAnalyzerTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputStepAnalyzerTest.java
@@ -21,6 +21,7 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.csvinput.CsvInput;
 import org.pentaho.di.trans.steps.csvinput.CsvInputMeta;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
 import org.pentaho.platform.api.metaverse.IComponentDescriptor;
@@ -48,6 +49,9 @@ import static org.mockito.Mockito.when;
 public class CsvFileInputStepAnalyzerTest {
 
   private CsvFileInputStepAnalyzer csvFileInputStepAnalyzer;
+
+  @Mock
+  private CsvInput mockCsvInput;
 
   @Mock
   private CsvInputMeta mockCsvInputMeta;
@@ -97,6 +101,7 @@ public class CsvFileInputStepAnalyzerTest {
     when( mockCsvInputMeta.getParentStepMeta() ).thenReturn( spyMeta );
     when( spyMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
     when( mockCsvInputMeta.getFilePaths( Mockito.any( VariableSpace.class ) ) ).thenReturn( fileNames );
+    when( mockCsvInput.getStepMetaInterface()).thenReturn( mockCsvInputMeta );
 
     IMetaverseNode result = csvFileInputStepAnalyzer.analyze( descriptor, mockCsvInputMeta );
     assertNotNull( result );
@@ -198,7 +203,7 @@ public class CsvFileInputStepAnalyzerTest {
 
     when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
       .thenThrow( KettleException.class );
-    resources = consumer.getResourcesFromRow( mockCsvInputMeta, mockRowMetaInterface, new String[]{ "id", "name" } );
+    resources = consumer.getResourcesFromRow( mockCsvInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 
     assertEquals( CsvInputMeta.class, consumer.getMetaClass() );

--- a/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputStepAnalyzerTest.java
+++ b/src/test/java/com/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputStepAnalyzerTest.java
@@ -42,6 +42,7 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.textfileinput.TextFileInput;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputMeta;
 import org.pentaho.platform.api.metaverse.IComponentDescriptor;
@@ -62,6 +63,9 @@ import static org.mockito.Mockito.*;
 public class TextFileInputStepAnalyzerTest {
 
   private TextFileInputStepAnalyzer textFileInputStepAnalyzer;
+
+  @Mock
+  private TextFileInput mockTextFileInput;
 
   @Mock
   private TextFileInputMeta mockTextFileInputMeta;
@@ -92,6 +96,8 @@ public class TextFileInputStepAnalyzerTest {
     textFileInputStepAnalyzer = new TextFileInputStepAnalyzer();
     textFileInputStepAnalyzer.setMetaverseBuilder( mockBuilder );
     descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_JOB, mockNamespace );
+
+    when( mockTextFileInput.getStepMetaInterface() ).thenReturn( mockTextFileInputMeta );
   }
 
   @Test( expected = MetaverseAnalyzerException.class )
@@ -293,13 +299,13 @@ public class TextFileInputStepAnalyzerTest {
     assertTrue( consumer.getResourcesFromMeta( mockTextFileInputMeta ).isEmpty() );
     when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
       .thenReturn( "/path/to/row/file" );
-    resources = consumer.getResourcesFromRow( mockTextFileInputMeta, mockRowMetaInterface, new String[]{ "id", "name" } );
+    resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
     when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
       .thenThrow( KettleException.class );
-    resources = consumer.getResourcesFromRow( mockTextFileInputMeta, mockRowMetaInterface, new String[]{ "id", "name" } );
+    resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 
     assertEquals( TextFileInputMeta.class, consumer.getMetaClass() );


### PR DESCRIPTION
Text File Output is the first step to need the StepDataInterface associated with an executing step during getResourcesByRow(), but in order to accomodate all, I refactored the interfaces so the IStepExternalResourceConsumer needs two parameterized types, the Step class and the BaseStepMeta class. As these are transformation-specific, I removed the type(s) from the IExternalResourceConsumer and the Job-based subclasses of such.
