### PR TITLE
[CLEANUP][BACKLOG-1801] Fixed various behaviors that cause errors on DI ...

### DIFF
--- a/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
+++ b/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
@@ -83,7 +83,7 @@ public class JobRuntimeExtensionPoint extends BaseRuntimeExtensionPoint implemen
 
       JobMeta jobMeta = job.getJobMeta();
 
-      File f = new File( job.getFilename() );
+      File f = new File( getFilename ( job ) );
 
       String filePath = null;
       try {
@@ -106,7 +106,8 @@ public class JobRuntimeExtensionPoint extends BaseRuntimeExtensionPoint implemen
 
       // Store execution information (client, server, user, etc.)
       executionData.setStartTime( new Timestamp( new Date().getTime() ) );
-      executionData.setClientExecutor( KettleClientEnvironment.getInstance().getClient().name() );
+      KettleClientEnvironment.ClientType clientType = KettleClientEnvironment.getInstance().getClient();
+      executionData.setClientExecutor( clientType == null ? "DI Server" : clientType.name() );
       executionData.setExecutorUser( job.getExecutingUser() );
       executionData.setExecutorServer( job.getExecutingServer() );
 
@@ -243,5 +244,16 @@ public class JobRuntimeExtensionPoint extends BaseRuntimeExtensionPoint implemen
   @Override
   public void jobStarted( Job job ) throws KettleException {
     // Do nothing, this method has already been called before the extension point could add the listener
+  }
+
+  public static String getFilename( Job job ) {
+    String filename = job.getFilename();
+    if ( filename == null && job.getJobMeta() != null ) {
+      filename = job.getJobMeta().getName();
+    }
+    if ( filename == null ) {
+      filename = "";
+    }
+    return filename;
   }
 }


### PR DESCRIPTION
...Server or Spoon

```
- executing a kettle job in DI-server fails with errors in JobRuntimeExtensionPoint
- applied in JobRuntimeExtensionPoint the same line of changes that have been applied in TransExtensionPointUtil
- @see https://github.com/pentaho/pentaho-metaverse-ee/commit/9e97773b0d419ffa83b6b6745032e935fbf96793
```
