### PR TITLE
[BACKLOG-1801] Reverted change, return to using TransOpened extension points

### DIFF
--- a/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransOpenedExtensionPoint.java
+++ b/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransOpenedExtensionPoint.java
@@ -34,7 +34,7 @@ import org.pentaho.platform.api.metaverse.MetaverseException;
  */
 @ExtensionPoint(
   description = "Transformation Lineage Graph creator",
-  extensionPointId = "TransformationMetaLoaded",
+  extensionPointId = "TransAfterOpen",
   id = "transOpenLineageGraph" )
 public class TransOpenedExtensionPoint implements ExtensionPointInterface {
 

--- a/core/src/main/resources/OSGI-INF/blueprint/pdi-plugins.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/pdi-plugins.xml
@@ -201,7 +201,7 @@
   <bean id="transOpened" scope="singleton" class="com.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransOpenedExtensionPoint"/>
   <bean id="transOpenedPlugin" scope="singleton" class="org.pentaho.di.osgi.OSGIPlugin">
     <property name="mainType" value="org.pentaho.di.core.extension.ExtensionPointInterface"/>
-    <property name="name" value="TransformationMetaLoaded"/>
+    <property name="name" value="TransAfterOpen"/>
     <property name="ID" value="transOpenLineageGraph"/>
     <property name="description" value="Creates a lineage graph for the transformation on open"/>
     <property name="pluginTypeInterface" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>


### PR DESCRIPTION
The correct fix is in https://github.com/pentaho/pentaho-kettle/pull/1109
