### PR TITLE
[BACKLOG-520] - Setting the context to runtime in the runtime extension ...

### DIFF
--- a/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
+++ b/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.BaseRuntimeExtensionPoint;
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint;
+import com.pentaho.metaverse.api.AnalysisContext;
 import com.pentaho.metaverse.api.Namespace;
 import com.pentaho.metaverse.api.model.LineageHolder;
 import com.pentaho.metaverse.impl.MetaverseCompletionService;
@@ -129,6 +130,7 @@ public class JobRuntimeExtensionPoint extends BaseRuntimeExtensionPoint implemen
         metaverseDocument.setName( jobMeta.getName() );
         metaverseDocument.setExtension( "ktr" );
         metaverseDocument.setMimeType( URLConnection.getFileNameMap().getContentTypeFor( "trans.ktr" ) );
+        metaverseDocument.setContext( new AnalysisContext( DictionaryConst.CONTEXT_RUNTIME ) );
         metaverseDocument.setProperty( DictionaryConst.PROPERTY_PATH, id );
         metaverseDocument.setProperty( DictionaryConst.PROPERTY_NAMESPACE, namespace.getNamespaceId() );
 

--- a/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
+++ b/core/src/main/java/com/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
@@ -25,6 +25,7 @@ import com.pentaho.dictionary.DictionaryConst;
 import com.pentaho.metaverse.analyzer.kettle.KettleAnalyzerUtil;
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.BaseRuntimeExtensionPoint;
 import com.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint;
+import com.pentaho.metaverse.api.AnalysisContext;
 import com.pentaho.metaverse.api.IDocument;
 import com.pentaho.metaverse.api.IDocumentAnalyzer;
 import com.pentaho.metaverse.api.IMetaverseBuilder;
@@ -150,6 +151,7 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
       metaverseDocument.setName( transMeta.getName() );
       metaverseDocument.setExtension( "ktr" );
       metaverseDocument.setMimeType( URLConnection.getFileNameMap().getContentTypeFor( "trans.ktr" ) );
+      metaverseDocument.setContext( new AnalysisContext( DictionaryConst.CONTEXT_RUNTIME ) );
       String normalizedPath;
       try {
         normalizedPath = KettleAnalyzerUtil.normalizeFilePath( id );

--- a/core/src/main/java/com/pentaho/metaverse/util/MetaverseUtil.java
+++ b/core/src/main/java/com/pentaho/metaverse/util/MetaverseUtil.java
@@ -199,14 +199,14 @@ public class MetaverseUtil {
       @Override
       public void run() {
         try {
-
-          analyzer.analyze(
-            new MetaverseComponentDescriptor(
-              document.getName(),
-              DictionaryConst.NODE_TYPE_TRANS,
-              document.getNamespace() ),
-            document
-          );
+          MetaverseComponentDescriptor docDescriptor = new MetaverseComponentDescriptor(
+            document.getName(),
+            DictionaryConst.NODE_TYPE_TRANS,
+            document.getNamespace() );
+          if ( document.getContext() != null ) {
+            docDescriptor.setContext( document.getContext() );
+          }
+          analyzer.analyze( docDescriptor, document );
         } catch ( MetaverseAnalyzerException mae ) {
           throw new RuntimeException( Messages.getString( "ERROR.AnalyzingDocument", document.getNamespaceId() ), mae );
         }


### PR DESCRIPTION
...points on the the documents to be analyzed. this allows for variable/parameter substitution at runtime for TableOutputStepAnalyzer in particular, but useful for any step analyzer.
