### PR TITLE
[BACKLOG-2632] Implement custom metaverse step analyzer for Job Executor

### DIFF
--- a/core/src/it/resources/repo/validation/exec_job.ktr
+++ b/core/src/it/resources/repo/validation/exec_job.ktr
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<transformation>
+  <info>
+    <name>exec_job</name>
+    <description/>
+    <extended_description/>
+    <trans_version/>
+    <trans_type>Normal</trans_type>
+    <directory>&#x2f;</directory>
+    <parameters>
+    </parameters>
+    <log>
+<trans-log-table><connection/>
+<schema/>
+<table/>
+<size_limit_lines/>
+<interval/>
+<timeout_days/>
+<field><id>ID_BATCH</id><enabled>Y</enabled><name>ID_BATCH</name></field><field><id>CHANNEL_ID</id><enabled>Y</enabled><name>CHANNEL_ID</name></field><field><id>TRANSNAME</id><enabled>Y</enabled><name>TRANSNAME</name></field><field><id>STATUS</id><enabled>Y</enabled><name>STATUS</name></field><field><id>LINES_READ</id><enabled>Y</enabled><name>LINES_READ</name><subject/></field><field><id>LINES_WRITTEN</id><enabled>Y</enabled><name>LINES_WRITTEN</name><subject/></field><field><id>LINES_UPDATED</id><enabled>Y</enabled><name>LINES_UPDATED</name><subject/></field><field><id>LINES_INPUT</id><enabled>Y</enabled><name>LINES_INPUT</name><subject/></field><field><id>LINES_OUTPUT</id><enabled>Y</enabled><name>LINES_OUTPUT</name><subject/></field><field><id>LINES_REJECTED</id><enabled>Y</enabled><name>LINES_REJECTED</name><subject/></field><field><id>ERRORS</id><enabled>Y</enabled><name>ERRORS</name></field><field><id>STARTDATE</id><enabled>Y</enabled><name>STARTDATE</name></field><field><id>ENDDATE</id><enabled>Y</enabled><name>ENDDATE</name></field><field><id>LOGDATE</id><enabled>Y</enabled><name>LOGDATE</name></field><field><id>DEPDATE</id><enabled>Y</enabled><name>DEPDATE</name></field><field><id>REPLAYDATE</id><enabled>Y</enabled><name>REPLAYDATE</name></field><field><id>LOG_FIELD</id><enabled>Y</enabled><name>LOG_FIELD</name></field><field><id>EXECUTING_SERVER</id><enabled>N</enabled><name>EXECUTING_SERVER</name></field><field><id>EXECUTING_USER</id><enabled>N</enabled><name>EXECUTING_USER</name></field><field><id>CLIENT</id><enabled>N</enabled><name>CLIENT</name></field></trans-log-table>
+<perf-log-table><connection/>
+<schema/>
+<table/>
+<interval/>
+<timeout_days/>
+<field><id>ID_BATCH</id><enabled>Y</enabled><name>ID_BATCH</name></field><field><id>SEQ_NR</id><enabled>Y</enabled><name>SEQ_NR</name></field><field><id>LOGDATE</id><enabled>Y</enabled><name>LOGDATE</name></field><field><id>TRANSNAME</id><enabled>Y</enabled><name>TRANSNAME</name></field><field><id>STEPNAME</id><enabled>Y</enabled><name>STEPNAME</name></field><field><id>STEP_COPY</id><enabled>Y</enabled><name>STEP_COPY</name></field><field><id>LINES_READ</id><enabled>Y</enabled><name>LINES_READ</name></field><field><id>LINES_WRITTEN</id><enabled>Y</enabled><name>LINES_WRITTEN</name></field><field><id>LINES_UPDATED</id><enabled>Y</enabled><name>LINES_UPDATED</name></field><field><id>LINES_INPUT</id><enabled>Y</enabled><name>LINES_INPUT</name></field><field><id>LINES_OUTPUT</id><enabled>Y</enabled><name>LINES_OUTPUT</name></field><field><id>LINES_REJECTED</id><enabled>Y</enabled><name>LINES_REJECTED</name></field><field><id>ERRORS</id><enabled>Y</enabled><name>ERRORS</name></field><field><id>INPUT_BUFFER_ROWS</id><enabled>Y</enabled><name>INPUT_BUFFER_ROWS</name></field><field><id>OUTPUT_BUFFER_ROWS</id><enabled>Y</enabled><name>OUTPUT_BUFFER_ROWS</name></field></perf-log-table>
+<channel-log-table><connection/>
+<schema/>
+<table/>
+<timeout_days/>
+<field><id>ID_BATCH</id><enabled>Y</enabled><name>ID_BATCH</name></field><field><id>CHANNEL_ID</id><enabled>Y</enabled><name>CHANNEL_ID</name></field><field><id>LOG_DATE</id><enabled>Y</enabled><name>LOG_DATE</name></field><field><id>LOGGING_OBJECT_TYPE</id><enabled>Y</enabled><name>LOGGING_OBJECT_TYPE</name></field><field><id>OBJECT_NAME</id><enabled>Y</enabled><name>OBJECT_NAME</name></field><field><id>OBJECT_COPY</id><enabled>Y</enabled><name>OBJECT_COPY</name></field><field><id>REPOSITORY_DIRECTORY</id><enabled>Y</enabled><name>REPOSITORY_DIRECTORY</name></field><field><id>FILENAME</id><enabled>Y</enabled><name>FILENAME</name></field><field><id>OBJECT_ID</id><enabled>Y</enabled><name>OBJECT_ID</name></field><field><id>OBJECT_REVISION</id><enabled>Y</enabled><name>OBJECT_REVISION</name></field><field><id>PARENT_CHANNEL_ID</id><enabled>Y</enabled><name>PARENT_CHANNEL_ID</name></field><field><id>ROOT_CHANNEL_ID</id><enabled>Y</enabled><name>ROOT_CHANNEL_ID</name></field></channel-log-table>
+<step-log-table><connection/>
+<schema/>
+<table/>
+<timeout_days/>
+<field><id>ID_BATCH</id><enabled>Y</enabled><name>ID_BATCH</name></field><field><id>CHANNEL_ID</id><enabled>Y</enabled><name>CHANNEL_ID</name></field><field><id>LOG_DATE</id><enabled>Y</enabled><name>LOG_DATE</name></field><field><id>TRANSNAME</id><enabled>Y</enabled><name>TRANSNAME</name></field><field><id>STEPNAME</id><enabled>Y</enabled><name>STEPNAME</name></field><field><id>STEP_COPY</id><enabled>Y</enabled><name>STEP_COPY</name></field><field><id>LINES_READ</id><enabled>Y</enabled><name>LINES_READ</name></field><field><id>LINES_WRITTEN</id><enabled>Y</enabled><name>LINES_WRITTEN</name></field><field><id>LINES_UPDATED</id><enabled>Y</enabled><name>LINES_UPDATED</name></field><field><id>LINES_INPUT</id><enabled>Y</enabled><name>LINES_INPUT</name></field><field><id>LINES_OUTPUT</id><enabled>Y</enabled><name>LINES_OUTPUT</name></field><field><id>LINES_REJECTED</id><enabled>Y</enabled><name>LINES_REJECTED</name></field><field><id>ERRORS</id><enabled>Y</enabled><name>ERRORS</name></field><field><id>LOG_FIELD</id><enabled>N</enabled><name>LOG_FIELD</name></field></step-log-table>
+<metrics-log-table><connection/>
+<schema/>
+<table/>
+<timeout_days/>
+<field><id>ID_BATCH</id><enabled>Y</enabled><name>ID_BATCH</name></field><field><id>CHANNEL_ID</id><enabled>Y</enabled><name>CHANNEL_ID</name></field><field><id>LOG_DATE</id><enabled>Y</enabled><name>LOG_DATE</name></field><field><id>METRICS_DATE</id><enabled>Y</enabled><name>METRICS_DATE</name></field><field><id>METRICS_CODE</id><enabled>Y</enabled><name>METRICS_CODE</name></field><field><id>METRICS_DESCRIPTION</id><enabled>Y</enabled><name>METRICS_DESCRIPTION</name></field><field><id>METRICS_SUBJECT</id><enabled>Y</enabled><name>METRICS_SUBJECT</name></field><field><id>METRICS_TYPE</id><enabled>Y</enabled><name>METRICS_TYPE</name></field><field><id>METRICS_VALUE</id><enabled>Y</enabled><name>METRICS_VALUE</name></field></metrics-log-table>
+    </log>
+    <maxdate>
+      <connection/>
+      <table/>
+      <field/>
+      <offset>0.0</offset>
+      <maxdiff>0.0</maxdiff>
+    </maxdate>
+    <size_rowset>10000</size_rowset>
+    <sleep_time_empty>50</sleep_time_empty>
+    <sleep_time_full>50</sleep_time_full>
+    <unique_connections>N</unique_connections>
+    <feedback_shown>Y</feedback_shown>
+    <feedback_size>50000</feedback_size>
+    <using_thread_priorities>Y</using_thread_priorities>
+    <shared_objects_file/>
+    <capture_step_performance>N</capture_step_performance>
+    <step_performance_capturing_delay>1000</step_performance_capturing_delay>
+    <step_performance_capturing_size_limit>100</step_performance_capturing_size_limit>
+    <dependencies>
+    </dependencies>
+    <partitionschemas>
+    </partitionschemas>
+    <slaveservers>
+    </slaveservers>
+    <clusterschemas>
+    </clusterschemas>
+  <created_user>-</created_user>
+  <created_date>2015&#x2f;07&#x2f;21 13&#x3a;03&#x3a;31.917</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2015&#x2f;07&#x2f;21 13&#x3a;03&#x3a;31.917</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA&#x3d;</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <connection>
+    <name>AgileBI</name>
+    <server>localhost</server>
+    <type>MONETDB</type>
+    <access>Native</access>
+    <database>pentaho-instaview</database>
+    <port>50000</port>
+    <username>monetdb</username>
+    <password>Encrypted 2be98afc86aa7f2e4cb14a17edb86abd8</password>
+    <servername/>
+    <data_tablespace/>
+    <index_tablespace/>
+    <read_only>true</read_only>
+    <attributes>
+      <attribute><code>EXTRA_OPTION_INFOBRIGHT.characterEncoding</code><attribute>UTF-8</attribute></attribute>
+      <attribute><code>EXTRA_OPTION_MYSQL.defaultFetchSize</code><attribute>500</attribute></attribute>
+      <attribute><code>EXTRA_OPTION_MYSQL.useCursorFetch</code><attribute>true</attribute></attribute>
+      <attribute><code>PORT_NUMBER</code><attribute>50000</attribute></attribute>
+      <attribute><code>PRESERVE_RESERVED_WORD_CASE</code><attribute>Y</attribute></attribute>
+      <attribute><code>SUPPORTS_BOOLEAN_DATA_TYPE</code><attribute>Y</attribute></attribute>
+      <attribute><code>SUPPORTS_TIMESTAMP_DATA_TYPE</code><attribute>Y</attribute></attribute>
+    </attributes>
+  </connection>
+  <order>
+  <hop> <from>Generate Rows</from><to>Job Executor</to><enabled>Y</enabled> </hop>
+  <hop> <from>Job Executor</from><to>Dummy &#x28;do nothing&#x29;</to><enabled>Y</enabled> </hop>
+  </order>
+  <step>
+    <name>Generate Rows</name>
+    <type>RowGenerator</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+         <partitioning>
+           <method>none</method>
+           <schema_name/>
+           </partitioning>
+    <fields>
+    </fields>
+    <limit>1</limit>
+    <never_ending>N</never_ending>
+    <interval_in_ms>5000</interval_in_ms>
+    <row_time_field>now</row_time_field>
+    <last_time_field>FiveSecondsAgo</last_time_field>
+     <cluster_schema/>
+ <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
+      <xloc>70</xloc>
+      <yloc>50</yloc>
+      <draw>Y</draw>
+      </GUI>
+    </step>
+
+  <step>
+    <name>Job Executor</name>
+    <type>JobExecutor</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+         <partitioning>
+           <method>none</method>
+           <schema_name/>
+           </partitioning>
+    <specification_method>filename</specification_method>
+    <job_object_id/>
+    <job_name/>
+    <filename>&#x24;&#x7b;Internal.Transformation.Filename.Directory&#x7d;&#x2f;jobentry-trans-executor&#x2f;jobentry-trans-executor.kjb</filename>
+    <directory_path/>
+    <group_size>1</group_size>
+    <group_field/>
+    <group_time/>
+    <parameters>
+      <inherit_all_vars>Y</inherit_all_vars>
+    </parameters>
+    <execution_result_target_step/>
+    <execution_time_field>ExecutionTime</execution_time_field>
+    <execution_result_field>ExecutionResult</execution_result_field>
+    <execution_errors_field>ExecutionNrErrors</execution_errors_field>
+    <execution_lines_read_field>ExecutionLinesRead</execution_lines_read_field>
+    <execution_lines_written_field>ExecutionLinesWritten</execution_lines_written_field>
+    <execution_lines_input_field>ExecutionLinesInput</execution_lines_input_field>
+    <execution_lines_output_field>ExecutionLinesOutput</execution_lines_output_field>
+    <execution_lines_rejected_field>ExecutionLinesRejected</execution_lines_rejected_field>
+    <execution_lines_updated_field>ExecutionLinesUpdated</execution_lines_updated_field>
+    <execution_lines_deleted_field>ExecutionLinesDeleted</execution_lines_deleted_field>
+    <execution_files_retrieved_field>ExecutionFilesRetrieved</execution_files_retrieved_field>
+    <execution_exit_status_field>ExecutionExitStatus</execution_exit_status_field>
+    <execution_log_text_field>ExecutionLogText</execution_log_text_field>
+    <execution_log_channelid_field>ExecutionLogChannelId</execution_log_channelid_field>
+    <result_rows_target_step/>
+    <result_rows_field>
+      <name>a</name>
+      <type>String</type>
+      <length>-1</length>
+      <precision>-1</precision>
+    </result_rows_field>
+    <result_rows_field>
+      <name>b</name>
+      <type>Integer</type>
+      <length>-1</length>
+      <precision>-1</precision>
+    </result_rows_field>
+    <result_rows_field>
+      <name>c</name>
+      <type>Boolean</type>
+      <length>-1</length>
+      <precision>-1</precision>
+    </result_rows_field>
+    <result_files_target_step/>
+    <result_files_file_name_field>FileName</result_files_file_name_field>
+     <cluster_schema/>
+ <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
+      <xloc>200</xloc>
+      <yloc>50</yloc>
+      <draw>Y</draw>
+      </GUI>
+    </step>
+
+  <step>
+    <name>Dummy &#x28;do nothing&#x29;</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+         <partitioning>
+           <method>none</method>
+           <schema_name/>
+           </partitioning>
+     <cluster_schema/>
+ <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
+      <xloc>340</xloc>
+      <yloc>50</yloc>
+      <draw>Y</draw>
+      </GUI>
+    </step>
+
+  <step_error_handling>
+  </step_error_handling>
+   <slave-step-copy-partition-distribution>
+</slave-step-copy-partition-distribution>
+   <slave_transformation>N</slave_transformation>
+
+</transformation>

--- a/core/src/it/resources/solution/system/pentahoObjects.spring.xml
+++ b/core/src/it/resources/solution/system/pentahoObjects.spring.xml
@@ -80,6 +80,8 @@
         class="org.pentaho.metaverse.analyzer.kettle.step.splitfields.SplitFieldsStepAnalyzer"/>
   <bean id="TransExecutorStepAnalyzer"
         class="org.pentaho.metaverse.analyzer.kettle.step.transexecutor.TransExecutorStepAnalyzer"/>
+  <bean id="JobExecutorStepAnalyzer"
+        class="org.pentaho.metaverse.analyzer.kettle.step.jobexecutor.JobExecutorStepAnalyzer"/>
   <bean id="RowsToResultStepAnalyzer"
         class="org.pentaho.metaverse.analyzer.kettle.step.rowstoresult.RowsToResultStepAnalyzer"/>
   <bean id="RowsFromResultStepAnalyzer"

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMap.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMap.java
@@ -1,0 +1,110 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.analyzer.kettle.extensionpoints.job;
+
+import org.pentaho.di.job.Job;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.model.LineageHolder;
+import org.pentaho.metaverse.util.MetaverseBeanUtil;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class is a singleton that provides a map from Jobs to LineageHolder objects, and can/should be used
+ * by runtime elements (such as extension points) to access shared lineage artifacts (MetaverseBuilder and
+ * Execution Profile, e.g.)
+ */
+public class JobLineageHolderMap {
+
+  private static JobLineageHolderMap INSTANCE = new JobLineageHolderMap();
+
+  private IMetaverseBuilder defaultMetaverseBuilder;
+
+  private Map<Job, LineageHolder> lineageHolderMap = new ConcurrentHashMap<>();
+
+  private JobLineageHolderMap() {
+    // Private constructor to enforce Singleton pattern
+  }
+
+  public static JobLineageHolderMap getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * For testing, injection, etc.
+   *
+   * @param instance
+   */
+  protected static void setInstance( final JobLineageHolderMap instance ) {
+    INSTANCE = instance;
+  }
+
+  public LineageHolder getLineageHolder( Job job ) {
+    LineageHolder holder = lineageHolderMap.get( job );
+    if ( holder == null ) {
+      holder = new LineageHolder();
+      lineageHolderMap.put( job, holder );
+    }
+    return holder;
+  }
+
+  public void putLineageHolder( Job job, LineageHolder holder ) {
+    lineageHolderMap.put( job, holder );
+  }
+
+  public IMetaverseBuilder getMetaverseBuilder( Job job ) {
+    if ( job != null ) {
+      if ( job.getParentJob() == null && job.getParentTrans() == null ) {
+        IMetaverseBuilder builder =
+          this.getLineageHolder( job ).getMetaverseBuilder();
+        if ( builder == null ) {
+          return getDefaultMetaverseBuilder();
+        } else {
+          return builder;
+        }
+      } else {
+        if ( job.getParentJob() != null ) {
+          // Get the builder for the job
+          return this.getMetaverseBuilder( job.getParentJob() );
+        } else {
+          return TransLineageHolderMap.getInstance().getMetaverseBuilder( job.getParentTrans() );
+        }
+      }
+    }
+    return null;
+  }
+
+  protected IMetaverseBuilder getDefaultMetaverseBuilder() {
+    if ( defaultMetaverseBuilder == null ) {
+      defaultMetaverseBuilder = (IMetaverseBuilder) MetaverseBeanUtil.getInstance().get( "IMetaverseBuilderPrototype" );
+    }
+    return defaultMetaverseBuilder;
+  }
+
+  protected void setDefaultMetaverseBuilder( IMetaverseBuilder builder ) {
+    defaultMetaverseBuilder = builder;
+  }
+
+}

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceConsumerListener.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceConsumerListener.java
@@ -30,7 +30,7 @@ import org.pentaho.di.job.JobExecutionExtension;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumer;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumerProvider;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
@@ -111,7 +111,7 @@ public class JobEntryExternalResourceConsumerListener implements ExtensionPointI
     if ( resources != null ) {
       // Add the resources to the execution profile
       IExecutionProfile executionProfile =
-        JobRuntimeExtensionPoint.getLineageHolder( jobEntry.getParentJob() ).getExecutionProfile();
+        JobLineageHolderMap.getInstance().getLineageHolder( jobEntry.getParentJob() ).getExecutionProfile();
       if ( executionProfile != null ) {
         String jobEntryName = jobEntry.getName();
         Map<String, List<IExternalResourceInfo>> resourceMap =

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceListener.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceListener.java
@@ -31,7 +31,7 @@ import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.resource.ResourceEntry;
 import org.pentaho.di.resource.ResourceReference;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.ExternalResourceInfoFactory;
 import org.pentaho.metaverse.api.model.IExecutionData;
@@ -61,7 +61,8 @@ public class JobEntryExternalResourceListener implements JobEntryListener {
 
   @Override
   public void afterExecution( Job job, JobEntryCopy jobEntryCopy, JobEntryInterface jobEntryInterface, Result result ) {
-    IExecutionProfile executionProfile = JobRuntimeExtensionPoint.getLineageHolder( job ).getExecutionProfile();
+    IExecutionProfile executionProfile =
+      JobLineageHolderMap.getInstance().getLineageHolder( job ).getExecutionProfile();
     IExecutionData executionData = executionProfile.getExecutionData();
 
     // Get input files (aka Resource Dependencies)

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
@@ -1,0 +1,109 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans;
+
+import org.pentaho.di.trans.Trans;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.model.LineageHolder;
+import org.pentaho.metaverse.util.MetaverseBeanUtil;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class is a singleton that provides a map from Jobs to LineageHolder objects, and can/should be used
+ * by runtime elements (such as extension points) to access shared lineage artifacts (MetaverseBuilder and
+ * Execution Profile, e.g.)
+ */
+public class TransLineageHolderMap {
+
+  private static TransLineageHolderMap INSTANCE = new TransLineageHolderMap();
+
+  private Map<Trans, LineageHolder> lineageHolderMap = new ConcurrentHashMap<>();
+
+  private IMetaverseBuilder defaultMetaverseBuilder;
+
+  private TransLineageHolderMap() {
+    // Private constructor to enforce Singleton pattern
+  }
+
+  public static TransLineageHolderMap getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * For testing, injection, etc.
+   *
+   * @param instance
+   */
+  protected static void setInstance( final TransLineageHolderMap instance ) {
+    INSTANCE = instance;
+  }
+
+  public LineageHolder getLineageHolder( Trans t ) {
+    LineageHolder holder = lineageHolderMap.get( t );
+    if ( holder == null ) {
+      holder = new LineageHolder();
+      putLineageHolder( t, holder );
+    }
+    return holder;
+  }
+
+  public void putLineageHolder( Trans t, LineageHolder holder ) {
+    lineageHolderMap.put( t, holder );
+  }
+
+  public IMetaverseBuilder getMetaverseBuilder( Trans trans ) {
+    if ( trans != null ) {
+      if ( trans.getParentJob() == null && trans.getParentTrans() == null ) {
+        IMetaverseBuilder builder =
+          this.getLineageHolder( trans ).getMetaverseBuilder();
+        if ( builder == null ) {
+          return getDefaultMetaverseBuilder();
+        } else {
+          return builder;
+        }
+      } else {
+        if ( trans.getParentJob() != null ) {
+          // Get the builder for the job
+          return JobLineageHolderMap.getInstance().getMetaverseBuilder( trans.getParentJob() );
+        } else {
+          return this.getMetaverseBuilder( trans.getParentTrans() );
+        }
+      }
+    }
+    return null;
+  }
+
+  protected IMetaverseBuilder getDefaultMetaverseBuilder() {
+    if ( defaultMetaverseBuilder == null ) {
+      defaultMetaverseBuilder = (IMetaverseBuilder) MetaverseBeanUtil.getInstance().get( "IMetaverseBuilderPrototype" );
+    }
+    return defaultMetaverseBuilder;
+  }
+
+  protected void setDefaultMetaverseBuilder( IMetaverseBuilder builder ) {
+    defaultMetaverseBuilder = builder;
+  }
+}

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListener.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListener.java
@@ -27,7 +27,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.RowAdapter;
 import org.pentaho.di.trans.step.StepInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
@@ -65,7 +65,7 @@ public class StepExternalConsumerRowListener extends RowAdapter {
     if ( resources != null ) {
       // Add the resources to the execution profile
       IExecutionProfile executionProfile =
-        TransformationRuntimeExtensionPoint.getLineageHolder( step.getTrans() ).getExecutionProfile();
+        TransLineageHolderMap.getInstance().getLineageHolder( step.getTrans() ).getExecutionProfile();
       if ( executionProfile != null ) {
         String stepName = step.getStepname();
         Map<String, List<IExternalResourceInfo>> resourceMap =

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalResourceConsumerListener.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalResourceConsumerListener.java
@@ -30,7 +30,7 @@ import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumer;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumerProvider;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
@@ -104,7 +104,7 @@ public class StepExternalResourceConsumerListener implements ExtensionPointInter
     if ( resources != null ) {
       // Add the resources to the execution profile
       IExecutionProfile executionProfile =
-        TransformationRuntimeExtensionPoint.getLineageHolder( step.getTrans() ).getExecutionProfile();
+        TransLineageHolderMap.getInstance().getLineageHolder( step.getTrans() ).getExecutionProfile();
       if ( executionProfile != null ) {
         String stepName = step.getStepname();
         Map<String, List<IExternalResourceInfo>> resourceMap =

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/jobexecutor/JobExecutorStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/jobexecutor/JobExecutorStepAnalyzer.java
@@ -1,0 +1,232 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.analyzer.kettle.step.jobexecutor;
+
+import org.apache.commons.lang.StringUtils;
+import org.pentaho.di.core.ProgressNullMonitorListener;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleMissingPluginsException;
+import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.jobexecutor.JobExecutorMeta;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IComponentDescriptor;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.MetaverseAnalyzerException;
+import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
+import org.pentaho.metaverse.api.StepField;
+import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
+import org.pentaho.metaverse.api.analyzer.kettle.step.StepAnalyzer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class JobExecutorStepAnalyzer extends StepAnalyzer<JobExecutorMeta> {
+
+  public static final String JOB_TO_EXECUTE = "jobToExecute";
+  public static final String EXECUTION_RESULTS_TARGET = "executionResultsTarget";
+  public static final String OUTPUT_ROWS_TARGET = "outputRowsTarget";
+  public static final String RESULT_FILES_TARGET = "resultFilesTarget";
+  private Logger log = LoggerFactory.getLogger( JobExecutorStepAnalyzer.class );
+
+
+  @Override
+  protected Set<StepField> getUsedFields( JobExecutorMeta meta ) {
+    // add uses links to all incoming fields
+    return getInputs().getFieldNames();
+  }
+
+  @Override
+  protected boolean isPassthrough( StepField originalFieldName ) {
+    // there are no passthrough fields
+    return false;
+  }
+
+  @Override
+  protected void customAnalyze( JobExecutorMeta meta, IMetaverseNode node )
+    throws MetaverseAnalyzerException {
+
+    String jobPath = meta.getFileName();
+    JobMeta subJobMeta = null;
+    Repository repo = parentTransMeta.getRepository();
+
+    switch ( meta.getSpecificationMethod() ) {
+      case FILENAME:
+        jobPath = parentTransMeta.environmentSubstitute( meta.getFileName() );
+        try {
+          String normalized = KettleAnalyzerUtil.normalizeFilePath( jobPath );
+
+          subJobMeta = getSubJobMeta( parentTransMeta, normalized );
+          jobPath = normalized;
+
+        } catch ( Exception e ) {
+          log.error( e.getMessage(), e );
+          throw new MetaverseAnalyzerException( "Sub transformation can not be found - " + jobPath, e );
+        }
+        break;
+      case REPOSITORY_BY_NAME:
+        if ( repo != null ) {
+          String dir = parentTransMeta.environmentSubstitute( meta.getDirectoryPath() );
+          String file = parentTransMeta.environmentSubstitute( meta.getJobName() );
+          try {
+            RepositoryDirectoryInterface rdi = repo.findDirectory( dir );
+            subJobMeta = repo.loadJob( file, rdi, null, null );
+            jobPath = subJobMeta.getName() + "." + subJobMeta.getDefaultExtension();
+          } catch ( KettleException e ) {
+            log.error( e.getMessage(), e );
+            throw new MetaverseAnalyzerException( "Sub transformation can not be found in repository - " + file, e );
+          }
+        } else {
+          throw new MetaverseAnalyzerException( "Not connected to a repository, can't get the transformation" );
+        }
+        break;
+      case REPOSITORY_BY_REFERENCE:
+        if ( repo != null ) {
+          try {
+            subJobMeta = repo.loadJob( meta.getJobObjectId(), null );
+            jobPath = subJobMeta.getName() + "." + subJobMeta.getDefaultExtension();
+          } catch ( KettleException e ) {
+            log.error( e.getMessage(), e );
+            throw new MetaverseAnalyzerException( "Sub transformation can not be found by reference - "
+              + meta.getJobObjectId(), e );
+          }
+        } else {
+          throw new MetaverseAnalyzerException( "Not connected to a repository, can't get the transformation" );
+        }
+        break;
+    }
+
+    // analyze the sub trans?
+
+    IComponentDescriptor ds = new MetaverseComponentDescriptor(
+      subJobMeta.getName(),
+      DictionaryConst.NODE_TYPE_JOB,
+      descriptor.getNamespace().getParentNamespace() );
+
+    IMetaverseNode jobNode = createNodeFromDescriptor( ds );
+    jobNode.setProperty( DictionaryConst.PROPERTY_NAMESPACE, ds.getNamespaceId() );
+    jobNode.setProperty( DictionaryConst.PROPERTY_PATH, jobPath );
+    jobNode.setLogicalIdGenerator( DictionaryConst.LOGICAL_ID_GENERATOR_DOCUMENT );
+
+    metaverseBuilder.addLink( node, DictionaryConst.LINK_EXECUTES, jobNode );
+
+    connectToSubJobOutputFields( meta, subJobMeta, jobNode, descriptor );
+
+    node.setProperty( JOB_TO_EXECUTE, jobPath );
+
+    if ( StringUtils.isNotEmpty( meta.getExecutionResultTargetStep() ) ) {
+      node.setProperty( EXECUTION_RESULTS_TARGET, meta.getExecutionResultTargetStep() );
+    }
+
+    /* TODO remove? if ( StringUtils.isNotEmpty( meta.getOutputRowsSourceStep() ) ) {
+      node.setProperty( OUTPUT_ROWS_TARGET, meta.getOutputRowsSourceStep() );
+    }*/
+
+    if ( StringUtils.isNotEmpty( meta.getResultFilesTargetStep() ) ) {
+      node.setProperty( RESULT_FILES_TARGET, meta.getResultFilesTargetStep() );
+    }
+
+  }
+
+  protected JobMeta getSubJobMeta( VariableSpace variableSpace, String filePath )
+    throws FileNotFoundException, KettleXMLException, KettleMissingPluginsException {
+    return new JobMeta( variableSpace, filePath, null, null, null );
+  }
+
+  protected void connectToSubJobOutputFields( JobExecutorMeta meta, JobMeta subJobMeta,
+                                              IMetaverseNode subTransNode,
+                                              IComponentDescriptor descriptor ) {
+
+    if ( meta.getResultRowsTargetStep() != null ) {
+      String outputStep = meta.getResultRowsTargetStep();
+
+      for ( int i = 0; i < meta.getResultRowsField().length; i++ ) {
+        String fieldName = meta.getResultRowsField()[i];
+        IMetaverseNode outNode = getOutputs().findNode( outputStep, fieldName );
+        // TODO
+        /* if ( outNode != null ) {
+          // add link, if needed, from sub tran result fields to the node just created
+           linkResultFieldToSubTrans( outNode, subJobMeta, subTransNode, descriptor );
+        }*/
+      }
+    }
+  }
+
+
+  @Override
+  protected Map<String, RowMetaInterface> getOutputRowMetaInterfaces( JobExecutorMeta meta ) {
+    Map<String, RowMetaInterface> outputFields = new HashMap<>();
+    String[] nextStepNames = parentTransMeta.getNextStepNames( parentStepMeta );
+    for ( int i = 0; i < nextStepNames.length; i++ ) {
+      String nextStepName = nextStepNames[i];
+      StepMeta step = parentTransMeta.findStep( nextStepName );
+      ProgressNullMonitorListener progressMonitor = new ProgressNullMonitorListener();
+      try {
+        RowMetaInterface prevStepFields = parentTransMeta.getPrevStepFields( step, progressMonitor );
+        outputFields.put( nextStepName, prevStepFields );
+        progressMonitor.done();
+      } catch ( KettleStepException e ) {
+        log.warn( "Could not get step fields for " + nextStepName, e );
+      }
+    }
+    return outputFields;
+  }
+
+  @Override
+  public Set<Class<? extends BaseStepMeta>> getSupportedSteps() {
+    HashSet<Class<? extends BaseStepMeta>> supportedSteps = new HashSet<Class<? extends BaseStepMeta>>();
+    supportedSteps.add( JobExecutorMeta.class );
+    return supportedSteps;
+  }
+
+  //// Used to aid unit testing
+  protected void setParentTransMeta( TransMeta parentTransMeta ) {
+    this.parentTransMeta = parentTransMeta;
+  }
+
+  protected void setParentStepMeta( StepMeta parentStepMeta ) {
+    this.parentStepMeta = parentStepMeta;
+  }
+
+  @Override
+  protected IMetaverseNode createFieldNode( IComponentDescriptor fieldDescriptor, ValueMetaInterface fieldMeta,
+                                            String targetStepName, boolean addTheNode ) {
+    // need access to spy on this in the unit test, have to override it and just call up to super
+    return super.createFieldNode( fieldDescriptor, fieldMeta, targetStepName, addTheNode );
+  }
+  ////////
+}

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -174,6 +174,8 @@
         class="org.pentaho.metaverse.analyzer.kettle.step.splitfields.SplitFieldsStepAnalyzer"/>
   <bean id="TransExecutorStepAnalyzer"
         class="org.pentaho.metaverse.analyzer.kettle.step.transexecutor.TransExecutorStepAnalyzer"/>
+  <bean id="JobExecutorStepAnalyzer"
+        class="org.pentaho.metaverse.analyzer.kettle.step.jobexecutor.JobExecutorStepAnalyzer"/>
   <bean id="RowsToResultStepAnalyzer"
         class="org.pentaho.metaverse.analyzer.kettle.step.rowstoresult.RowsToResultStepAnalyzer"/>
   <bean id="RowsFromResultStepAnalyzer"
@@ -296,6 +298,10 @@
   <service id="transExecutorStepAnalyzerService"
            interface="org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzer"
            ref="TransExecutorStepAnalyzer"/>
+
+  <service id="jobExecutorStepAnalyzerService"
+           interface="org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzer"
+           ref="JobExecutorStepAnalyzer"/>
 
   <service id="rowsToResultStepAnalyzerService"
            interface="org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzer"

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
@@ -1,0 +1,130 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.analyzer.kettle.extensionpoints.job;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.job.Job;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.model.IExecutionProfile;
+import org.pentaho.metaverse.api.model.LineageHolder;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for JobLineageHolderMap
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class JobLineageHolderMapTest {
+
+  JobLineageHolderMap jobLineageHolderMap;
+
+  // Will be a spy
+  LineageHolder mockHolder;
+
+  @Mock
+  IMetaverseBuilder mockBuilder;
+
+  @Mock
+  IMetaverseBuilder defaultBuilder;
+
+  @Mock
+  IExecutionProfile mockExecutionProfile;
+
+  @Before
+  public void setUp() throws Exception {
+    jobLineageHolderMap = JobLineageHolderMap.getInstance();
+    mockHolder = spy( new LineageHolder() );
+    jobLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );
+  }
+
+  @Test
+  public void testGetSetInstance() throws Exception {
+    assertNotNull( jobLineageHolderMap );
+    JobLineageHolderMap.setInstance( jobLineageHolderMap );
+    assertEquals( jobLineageHolderMap, JobLineageHolderMap.getInstance() );
+  }
+
+  @Test
+  public void testGetPutLineageHolder() throws Exception {
+
+    Job job = mock( Job.class );
+
+    LineageHolder holder = jobLineageHolderMap.getLineageHolder( job );
+    assertNotNull( holder ); // We always get a (perhaps empty) holder
+    assertFalse( holder == mockHolder );
+    assertNull( holder.getExecutionProfile() );
+    assertNull( holder.getMetaverseBuilder() );
+
+    mockHolder.setMetaverseBuilder( mockBuilder );
+    mockHolder.setExecutionProfile( mockExecutionProfile );
+    jobLineageHolderMap.putLineageHolder( job, mockHolder );
+
+    holder = jobLineageHolderMap.getLineageHolder( job );
+    assertNotNull( holder ); // We always get a (perhaps empty) holder
+    assertTrue( holder == mockHolder );
+    assertTrue( holder.getExecutionProfile() == mockExecutionProfile );
+    assertTrue( holder.getMetaverseBuilder() == mockBuilder );
+  }
+
+  @Test
+  public void testGetMetaverseBuilder() throws Exception {
+
+    assertNull( jobLineageHolderMap.getMetaverseBuilder( null ) );
+
+    Job job = mock( Job.class );
+    when( job.getParentJob() ).thenReturn( null );
+    when( job.getParentTrans() ).thenReturn( null );
+
+    mockHolder.setMetaverseBuilder( mockBuilder );
+    jobLineageHolderMap.putLineageHolder( job, mockHolder );
+
+    IMetaverseBuilder builder = jobLineageHolderMap.getMetaverseBuilder( job );
+    assertNotNull( builder );
+
+    Job parentJob = mock( Job.class );
+    when( parentJob.getParentJob() ).thenReturn( null );
+    when( parentJob.getParentTrans() ).thenReturn( null );
+
+    when( job.getParentJob() ).thenReturn( parentJob );
+
+    LineageHolder mockParentHolder = spy( new LineageHolder() );
+
+    IMetaverseBuilder mockParentBuilder = mock( IMetaverseBuilder.class );
+    jobLineageHolderMap.putLineageHolder( parentJob, mockParentHolder );
+    mockParentHolder.setMetaverseBuilder( null );
+
+    assertEquals( defaultBuilder, jobLineageHolderMap.getMetaverseBuilder( job ) );
+
+    mockParentHolder.setMetaverseBuilder( mockParentBuilder );
+    builder = jobLineageHolderMap.getMetaverseBuilder( job );
+    assertNotNull( builder );
+
+  }
+}

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPointTest.java
@@ -93,11 +93,17 @@ public class JobRuntimeExtensionPointTest {
   @Test
   public void testCallExtensionPoint() throws Exception {
     JobRuntimeExtensionPoint spyJobExtensionPoint = spy( jobExtensionPoint );
-    when( spyJobExtensionPoint.getMetaverseBuilder( Mockito.any( Job.class ) ) ).thenReturn( mockBuilder );
+    JobLineageHolderMap originalHolderMap = JobLineageHolderMap.getInstance();
+    JobLineageHolderMap jobLineageHolderMap = spy( originalHolderMap );
+    when( jobLineageHolderMap.getMetaverseBuilder( Mockito.any( Job.class ) ) ).thenReturn( mockBuilder );
+    JobLineageHolderMap.setInstance( jobLineageHolderMap );
     spyJobExtensionPoint.callExtensionPoint( null, job );
     List<JobListener> listeners = job.getJobListeners();
     assertNotNull( listeners );
     assertTrue( listeners.contains( spyJobExtensionPoint ) );
+
+    // Restore original JobLineageHolderMap for use by others
+    JobLineageHolderMap.setInstance( originalHolderMap );
   }
 
   @Test
@@ -130,6 +136,6 @@ public class JobRuntimeExtensionPointTest {
 
     IExecutionData executionData = mock( IExecutionData.class );
     when( executionProfile.getExecutionData() ).thenReturn( executionData );
-    JobRuntimeExtensionPoint.getLineageHolder( job ).setExecutionProfile( executionProfile );
+    JobLineageHolderMap.getInstance().getLineageHolder( job ).setExecutionProfile( executionProfile );
   }
 }

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceConsumerListenerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceConsumerListenerTest.java
@@ -29,7 +29,7 @@ import org.pentaho.di.job.JobExecutionExtension;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.analyzer.kettle.jobentry.JobEntryExternalResourceConsumerProvider;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExecutionData;
@@ -92,7 +92,7 @@ public class JobEntryExternalResourceConsumerListenerTest {
     IExecutionProfile executionProfile = mock( IExecutionProfile.class );
     IExecutionData executionData = mock( IExecutionData.class );
     when( executionProfile.getExecutionData() ).thenReturn( executionData );
-    JobRuntimeExtensionPoint.getLineageHolder( mockJob).setExecutionProfile( executionProfile );
+    JobLineageHolderMap.getInstance().getLineageHolder( mockJob ).setExecutionProfile( executionProfile );
 
     Collection<IExternalResourceInfo> externalResources = new ArrayList<IExternalResourceInfo>();
     stepExtensionPoint.addExternalResources( externalResources, mockJobEntry );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceListenerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/entry/JobEntryExternalResourceListenerTest.java
@@ -34,7 +34,7 @@ import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.resource.ResourceEntry;
 import org.pentaho.di.resource.ResourceReference;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExecutionData;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
@@ -68,7 +68,7 @@ public class JobEntryExternalResourceListenerTest {
     IExecutionProfile executionProfile = mock( IExecutionProfile.class );
     IExecutionData executionData = mock( IExecutionData.class );
     when( executionProfile.getExecutionData() ).thenReturn( executionData );
-    JobRuntimeExtensionPoint.getLineageHolder( job ).setExecutionProfile( executionProfile );
+    JobLineageHolderMap.getInstance().getLineageHolder( job ).setExecutionProfile( executionProfile );
 
     JobEntryExternalResourceListener listener = new JobEntryExternalResourceListener( consumer );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
@@ -1,0 +1,129 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.model.IExecutionProfile;
+import org.pentaho.metaverse.api.model.LineageHolder;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for TransLineageHolderMap
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class TransLineageHolderMapTest {
+
+  TransLineageHolderMap jobLineageHolderMap;
+
+  // Will be a spy
+  LineageHolder mockHolder;
+
+  @Mock
+  IMetaverseBuilder mockBuilder;
+
+  @Mock
+  IMetaverseBuilder defaultBuilder;
+
+  @Mock
+  IExecutionProfile mockExecutionProfile;
+
+  @Before
+  public void setUp() throws Exception {
+    jobLineageHolderMap = TransLineageHolderMap.getInstance();
+    mockHolder = spy( new LineageHolder() );
+    jobLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );
+  }
+
+  @Test
+  public void testGetSetInstance() throws Exception {
+    assertNotNull( jobLineageHolderMap );
+    TransLineageHolderMap.setInstance( jobLineageHolderMap );
+    assertEquals( jobLineageHolderMap, TransLineageHolderMap.getInstance() );
+  }
+
+  @Test
+  public void testGetPutLineageHolder() throws Exception {
+
+    Trans trans = mock( Trans.class );
+
+    LineageHolder holder = jobLineageHolderMap.getLineageHolder( trans );
+    assertNotNull( holder ); // We always get a (perhaps empty) holder
+    assertFalse( holder == mockHolder );
+    assertNull( holder.getExecutionProfile() );
+    assertNull( holder.getMetaverseBuilder() );
+
+    mockHolder.setMetaverseBuilder( mockBuilder );
+    mockHolder.setExecutionProfile( mockExecutionProfile );
+    jobLineageHolderMap.putLineageHolder( trans, mockHolder );
+
+    holder = jobLineageHolderMap.getLineageHolder( trans );
+    assertNotNull( holder ); // We always get a (perhaps empty) holder
+    assertTrue( holder == mockHolder );
+    assertTrue( holder.getExecutionProfile() == mockExecutionProfile );
+    assertTrue( holder.getMetaverseBuilder() == mockBuilder );
+  }
+
+  @Test
+  public void testGetMetaverseBuilder() throws Exception {
+
+    assertNull( jobLineageHolderMap.getMetaverseBuilder( null ) );
+
+    Trans trans = mock( Trans.class );
+    when( trans.getParentJob() ).thenReturn( null );
+    when( trans.getParentTrans() ).thenReturn( null );
+
+    mockHolder.setMetaverseBuilder( mockBuilder );
+    jobLineageHolderMap.putLineageHolder( trans, mockHolder );
+
+    IMetaverseBuilder builder = jobLineageHolderMap.getMetaverseBuilder( trans );
+    assertNotNull( builder );
+
+    Trans parentTrans = mock( Trans.class );
+    when( parentTrans.getParentJob() ).thenReturn( null );
+    when( parentTrans.getParentTrans() ).thenReturn( null );
+
+    when( trans.getParentTrans() ).thenReturn( parentTrans );
+
+    LineageHolder mockParentHolder = spy( new LineageHolder() );
+
+    IMetaverseBuilder mockParentBuilder = mock( IMetaverseBuilder.class );
+    jobLineageHolderMap.putLineageHolder( parentTrans, mockParentHolder );
+    mockParentHolder.setMetaverseBuilder( null );
+
+    assertEquals( defaultBuilder, jobLineageHolderMap.getMetaverseBuilder( trans ) );
+
+    mockParentHolder.setMetaverseBuilder( mockParentBuilder );
+    builder = jobLineageHolderMap.getMetaverseBuilder( trans );
+    assertNotNull( builder );
+  }
+}

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
@@ -103,7 +103,10 @@ public class TransformationRuntimeExtensionPointTest {
   @Test
   public void testTransStarted() throws Exception {
     TransformationRuntimeExtensionPoint ext = spy( transExtensionPoint );
-    when( ext.getMetaverseBuilder( Mockito.any( Trans.class ) ) ).thenReturn( mock( IMetaverseBuilder.class ) );
+    TransLineageHolderMap transLineageHolderMap = spy( TransLineageHolderMap.getInstance() );
+    when( transLineageHolderMap.getMetaverseBuilder( Mockito.any( Trans.class ) ) )
+      .thenReturn( mock( IMetaverseBuilder.class ) );
+    TransLineageHolderMap.setInstance( transLineageHolderMap );
     ext.transStarted( null );
     verify( ext, never() ).populateExecutionProfile(
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
@@ -121,15 +124,13 @@ public class TransformationRuntimeExtensionPointTest {
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
 
     ext.transFinished( trans );
-    verify( ext, times( 1 ) ).populateExecutionProfile(
-      Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
+    // The logic in transFinished() is now in a thread, so we can't verify methods were called
 
     Trans mockTrans = spy( trans );
     Result result = mock( Result.class );
     when( mockTrans.getResult() ).thenReturn( result );
     ext.transFinished( mockTrans );
-    verify( ext, times( 2 ) ).populateExecutionProfile(
-      Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
+    // The logic in transFinished() is now in a thread, so we can't verify methods were called
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListenerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalConsumerRowListenerTest.java
@@ -30,7 +30,7 @@ import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExecutionData;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
@@ -57,7 +57,7 @@ public class StepExternalConsumerRowListenerTest {
     when( executionProfile.getExecutionData() ).thenReturn( executionData );
     LineageHolder holder = new LineageHolder(  );
     holder.setExecutionProfile( executionProfile );
-    TransformationRuntimeExtensionPoint.putLineageHolder( mockTrans, holder );
+    TransLineageHolderMap.getInstance().putLineageHolder( mockTrans, holder );
 
     StepExternalConsumerRowListener listener = new StepExternalConsumerRowListener( consumer, mockStep );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalResourceConsumerListenerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/step/StepExternalResourceConsumerListenerTest.java
@@ -30,7 +30,7 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint;
+import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.analyzer.kettle.step.StepExternalResourceConsumerProvider;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExecutionData;
@@ -94,7 +94,7 @@ public class StepExternalResourceConsumerListenerTest {
     when( executionProfile.getExecutionData() ).thenReturn( executionData );
     LineageHolder holder = new LineageHolder();
     holder.setExecutionProfile( executionProfile );
-    TransformationRuntimeExtensionPoint.putLineageHolder( mockTrans, holder );
+    TransLineageHolderMap.getInstance().putLineageHolder( mockTrans, holder );
 
     Collection<IExternalResourceInfo> externalResources = new ArrayList<IExternalResourceInfo>();
     stepExtensionPoint.addExternalResources( externalResources, mockStep );


### PR DESCRIPTION
Did some refactoring for the LineageHolders, also moved job/transFinished logic out into a thread, so as not to impact the performance of the job/trans.

Note the result row fields aren't created, there is no need until we have field-level lineage in jobs (see BACKLOG-3671)