### PR TITLE
[BACKLOG-5070] Lineage analyzer fixes for old and new Text File Input steps

### DIFF
--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
@@ -461,7 +461,7 @@ public class MetaverseValidationIT {
       assertTrue( inputFile.getName().endsWith( "SacramentocrimeJanuary2006.csv" ) );
     }
 
-    assertEquals( "Text file input", fileInputStepNode.getStepType() );
+    assertEquals( "Old Text file input", fileInputStepNode.getStepType() );
 
     int countUses = getIterableSize( fileInputStepNode.getFileFieldNodesUses() );
     int countInputs = getIterableSize( fileInputStepNode.getInputStreamFields() );

--- a/core/src/it/resources/metaverse-pdi.groovy
+++ b/core/src/it/resources/metaverse-pdi.groovy
@@ -38,7 +38,7 @@ import org.pentaho.metaverse.analyzer.kettle.step.stringoperations.StringOperati
 import org.pentaho.metaverse.analyzer.kettle.step.stringscut.StringsCutStepAnalyzer
 import org.pentaho.metaverse.analyzer.kettle.step.stringsreplace.StringsReplaceStepAnalyzer
 import org.pentaho.metaverse.analyzer.kettle.step.tableoutput.TableOutputStepAnalyzer
-import org.pentaho.metaverse.analyzer.kettle.step.textfileinput.TextFileInputStepAnalyzer
+import org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput.TextFileInputStepAnalyzer
 import org.pentaho.metaverse.analyzer.kettle.step.transexecutor.TransExecutorStepAnalyzer
 import org.pentaho.metaverse.analyzer.kettle.step.valuemapper.ValueMapperStepAnalyzer
 import org.pentaho.metaverse.api.Namespace

--- a/core/src/it/resources/repo/samples/file_to_table.ktr
+++ b/core/src/it/resources/repo/samples/file_to_table.ktr
@@ -183,7 +183,7 @@
 
   <step>
     <name>Sacramento crime stats 2006 file </name>
-    <type>TextFileInput</type>
+    <type>OldTextFileInput</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>

--- a/core/src/it/resources/repo/validation/file_to_table.ktr
+++ b/core/src/it/resources/repo/validation/file_to_table.ktr
@@ -583,7 +583,7 @@
 
   <step>
     <name>Sacramento crime stats 2006 file</name>
-    <type>TextFileInput</type>
+    <type>OldTextFileInput</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>

--- a/core/src/it/resources/solution/system/pentahoObjects.spring.xml
+++ b/core/src/it/resources/solution/system/pentahoObjects.spring.xml
@@ -40,7 +40,7 @@
   </bean>
 
   <bean id="TextFileInputStepAnalyzer"
-        class="org.pentaho.metaverse.analyzer.kettle.step.textfileinput.TextFileInputStepAnalyzer">
+        class="org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput.TextFileInputStepAnalyzer">
     <property name="externalResourceConsumer" ref="textFileInputERC"/>
   </bean>
   <bean id="SelectValuesStepAnalyzer"
@@ -195,7 +195,7 @@
   <bean id="tableOutputERC" scope="singleton"
         class="org.pentaho.metaverse.analyzer.kettle.step.tableoutput.TableOutputExternalResourceConsumer"/>
   <bean id="textFileInputERC" scope="singleton"
-        class="org.pentaho.metaverse.analyzer.kettle.step.textfileinput.TextFileInputExternalResourceConsumer"/>
+        class="org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput.TextFileInputExternalResourceConsumer"/>
   <bean id="textFileOutputERC" scope="singleton"
         class="org.pentaho.metaverse.analyzer.kettle.step.textfileoutput.TextFileOutputExternalResourceConsumer"/>
   <bean id="excelInputERC" scope="singleton"

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputExternalResourceConsumer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputExternalResourceConsumer.java
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-package org.pentaho.metaverse.analyzer.kettle.step.textfileinput;
+package org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput;
 
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.Const;

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputStepAnalyzer.java
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-package org.pentaho.metaverse.analyzer.kettle.step.textfileinput;
+package org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput;
 
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.trans.step.BaseStepMeta;

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -136,7 +136,7 @@
   </bean>
 
   <bean id="TextFileInputStepAnalyzer"
-        class="org.pentaho.metaverse.analyzer.kettle.step.textfileinput.TextFileInputStepAnalyzer">
+        class="org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput.TextFileInputStepAnalyzer">
     <property name="externalResourceConsumer" ref="textFileInputERC"/>
   </bean>
   <bean id="SelectValuesStepAnalyzer"
@@ -384,7 +384,7 @@
   <bean id="tableOutputERC" scope="singleton"
         class="org.pentaho.metaverse.analyzer.kettle.step.tableoutput.TableOutputExternalResourceConsumer"/>
   <bean id="textFileInputERC" scope="singleton"
-        class="org.pentaho.metaverse.analyzer.kettle.step.textfileinput.TextFileInputExternalResourceConsumer"/>
+        class="org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput.TextFileInputExternalResourceConsumer"/>
   <bean id="textFileOutputERC" scope="singleton"
         class="org.pentaho.metaverse.analyzer.kettle.step.textfileoutput.TextFileOutputExternalResourceConsumer"/>
   <bean id="excelInputERC" scope="singleton"

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/oldtextfileinput/TextFileInputStepAnalyzerTest.java
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-package org.pentaho.metaverse.analyzer.kettle.step.textfileinput;
+package org.pentaho.metaverse.analyzer.kettle.step.oldtextfileinput;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Fixes two of the integration-test errors by changing the validation KTRs to use the deprecated step ID and moves the analyzers for the old step into an "oldtextfileinput" package.