### PR TITLE
[BACKLOG-5070] Lineage analyzer fixes for old and new Text File Input steps

### DIFF
--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
@@ -461,7 +461,7 @@ public class MetaverseValidationIT {
       assertTrue( inputFile.getName().endsWith( "SacramentocrimeJanuary2006.csv" ) );
     }
 
-    assertEquals( "Text file input", fileInputStepNode.getStepType() );
+    assertEquals( "Old Text file input", fileInputStepNode.getStepType() );
 
     int countUses = getIterableSize( fileInputStepNode.getFileFieldNodesUses() );
     int countInputs = getIterableSize( fileInputStepNode.getInputStreamFields() );

--- a/core/src/it/resources/repo/samples/file_to_table.ktr
+++ b/core/src/it/resources/repo/samples/file_to_table.ktr
@@ -183,7 +183,7 @@
 
   <step>
     <name>Sacramento crime stats 2006 file </name>
-    <type>TextFileInput</type>
+    <type>OldTextFileInput</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>

--- a/core/src/it/resources/repo/validation/file_to_table.ktr
+++ b/core/src/it/resources/repo/validation/file_to_table.ktr
@@ -583,7 +583,7 @@
 
   <step>
     <name>Sacramento crime stats 2006 file</name>
-    <type>TextFileInput</type>
+    <type>OldTextFileInput</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>


### PR DESCRIPTION
Fixes two integration test failures by changing references to the old
TFI to match the correct step ID for it.  Leaves the package names
alone.