### PR TITLE
[BACKLOG-5308] Disable runtime lineage by default

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -99,7 +99,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${dependency.com.google.guava.guava.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/BaseRuntimeExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/BaseRuntimeExtensionPoint.java
@@ -45,6 +45,8 @@ public abstract class BaseRuntimeExtensionPoint implements ExtensionPointInterfa
 
   protected ILineageWriter lineageWriter;
 
+  protected boolean runtimeEnabled;
+
   public void writeLineageInfo( LineageHolder holder ) throws IOException {
     if ( lineageWriter != null ) {
       String strategy = lineageWriter.getOutputStrategy();
@@ -95,5 +97,17 @@ public abstract class BaseRuntimeExtensionPoint implements ExtensionPointInterfa
    */
   public void setLineageWriter( ILineageWriter lineageWriter ) {
     this.lineageWriter = lineageWriter;
+  }
+
+  public void setRuntimeEnabled( String runtimeEnabled ) {
+    this.runtimeEnabled = ( runtimeEnabled != null && runtimeEnabled.equalsIgnoreCase( "on" ) );
+  }
+
+  public void setRuntimeEnabled( boolean runtimeEnabled ) {
+    this.runtimeEnabled = runtimeEnabled;
+  }
+
+  public boolean isRuntimeEnabled() {
+    return runtimeEnabled;
   }
 }

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMap.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMap.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.metaverse.analyzer.kettle.extensionpoints.job;
 
+import com.google.common.collect.MapMaker;
 import org.pentaho.di.job.Job;
 import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
@@ -42,7 +43,7 @@ public class JobLineageHolderMap {
 
   private IMetaverseBuilder defaultMetaverseBuilder;
 
-  private Map<Job, LineageHolder> lineageHolderMap = new ConcurrentHashMap<>();
+  private Map<Job, LineageHolder> lineageHolderMap = new MapMaker().weakKeys().makeMap();
 
   private JobLineageHolderMap() {
     // Private constructor to enforce Singleton pattern
@@ -98,7 +99,8 @@ public class JobLineageHolderMap {
 
   protected IMetaverseBuilder getDefaultMetaverseBuilder() {
     // always try to get a new builder if this method is called. otherwise we will end up with overlapping graphs
-    IMetaverseBuilder newBuilder = (IMetaverseBuilder) MetaverseBeanUtil.getInstance().get( "IMetaverseBuilderPrototype" );
+    IMetaverseBuilder newBuilder =
+      (IMetaverseBuilder) MetaverseBeanUtil.getInstance().get( "IMetaverseBuilderPrototype" );
     if ( newBuilder == null ) {
       return defaultMetaverseBuilder;
     } else {

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPoint.java
@@ -96,6 +96,11 @@ public class JobRuntimeExtensionPoint extends BaseRuntimeExtensionPoint implemen
     if ( o instanceof Job ) {
       Job job = ( (Job) o );
 
+      // If runtime lineage collection is disabled, don't run any lineage processes/methods
+      if( !isRuntimeEnabled() ) {
+        return;
+      }
+
       // Create and populate an execution profile with what we know so far
       ExecutionProfile executionProfile = new ExecutionProfile();
       populateExecutionProfile( executionProfile, job );

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
@@ -22,6 +22,8 @@
 
 package org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans;
 
+import com.google.common.collect.MapMaker;
+
 import org.pentaho.di.trans.Trans;
 import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
@@ -29,7 +31,6 @@ import org.pentaho.metaverse.api.model.LineageHolder;
 import org.pentaho.metaverse.util.MetaverseBeanUtil;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class is a singleton that provides a map from Jobs to LineageHolder objects, and can/should be used
@@ -40,7 +41,7 @@ public class TransLineageHolderMap {
 
   private static TransLineageHolderMap INSTANCE = new TransLineageHolderMap();
 
-  private Map<Trans, LineageHolder> lineageHolderMap = new ConcurrentHashMap<>();
+  private Map<Trans, LineageHolder> lineageHolderMap = new MapMaker().weakKeys().makeMap();
 
   private IMetaverseBuilder defaultMetaverseBuilder;
 

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
@@ -91,8 +91,14 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
   public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
 
     // Transformation Started listeners get called after the extension point is invoked, so just add a trans listener
-    if ( o instanceof Trans ) {
+    if ( o != null && o instanceof Trans ) {
       Trans trans = ( (Trans) o );
+
+      // Only generate lineage/execution information for "real" transformations, not the preview or debug ones. Whether
+      // in Preview or Debug mode in Spoon, trans.isPreview() returns true, so just check that.
+      if ( trans.isPreview() || !isRuntimeEnabled() ) {
+        return;
+      }
       trans.addTransListener( this );
     }
 
@@ -106,13 +112,8 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
    */
   @Override
   public void transStarted( Trans trans ) throws KettleException {
-    if ( trans == null ) {
-      return;
-    }
 
-    // Only generate lineage/execution information for "real" transformations, not the preview or debug ones. Whether
-    // in Preview or Debug mode in Spoon, trans.isPreview() returns true, so just check that.
-    if ( trans.isPreview() ) {
+    if ( trans == null ) {
       return;
     }
 

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,11 +11,12 @@
              ">
 
 
-  <!-- Put all properties (for user config of lineage) here -->
+  <!-- Put properties (for user config of lineage) here -->
   <cm:property-placeholder persistent-id="pentaho.metaverse" update-strategy="reload" >
     <cm:default-properties>
+      <cm:property name="lineage.execution.runtime" value="off"/>
       <cm:property name="lineage.execution.output.folder" value="./pentaho-lineage-output"/>
-      <cm:property name="lineage.execution.generation.strategy" value="none"/>
+      <cm:property name="lineage.execution.generation.strategy" value="latest"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -630,6 +631,58 @@
       </set>
     </argument>
   </bean>
+
+  <!-- TransRuntime extension point -->
+  <bean id="transRuntime" scope="singleton" class="org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint">
+    <property name="documentAnalyzer" ref="TransformationAnalyzer"/>
+    <property name="lineageWriter" ref="lineageWriter"/>
+    <property name="runtimeEnabled" value="${lineage.execution.runtime}"/>
+  </bean>
+  <bean id="transRuntimePlugin" scope="singleton" class="org.pentaho.di.osgi.OSGIPlugin">
+    <property name="mainType" value="org.pentaho.di.core.extension.ExtensionPointInterface"/>
+    <property name="name" value="TransformationStartThreads"/>
+    <property name="ID" value="transRuntimeMetaverse"/>
+    <property name="description" value="Creates execution profiles when transformations run"/>
+    <property name="pluginTypeInterface" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
+    <property name="category" value="Data Lineage"/>
+    <property name="classToBeanMap">
+      <map>
+        <entry key="org.pentaho.di.core.extension.ExtensionPointInterface" value="transRuntime"/>
+        <entry key="org.pentaho.di.trans.TransListener" value="transRuntime"/>
+      </map>
+    </property>
+  </bean>
+  <service id="transRuntimePluginService" interface="org.pentaho.di.core.plugins.PluginInterface" ref="transRuntimePlugin">
+    <service-properties>
+      <entry key="PluginType" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
+    </service-properties>
+  </service>
+
+  <!-- JobRuntime extension point -->
+  <bean id="jobRuntime" scope="singleton" class="org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint">
+    <property name="documentAnalyzer" ref="JobAnalyzer"/>
+    <property name="lineageWriter" ref="lineageWriter"/>
+    <property name="runtimeEnabled" value="${lineage.execution.runtime}"/>
+  </bean>
+  <bean id="jobRuntimePlugin" scope="singleton" class="org.pentaho.di.osgi.OSGIPlugin">
+    <property name="mainType" value="org.pentaho.di.core.extension.ExtensionPointInterface"/>
+    <property name="name" value="JobStart"/>
+    <property name="ID" value="jobRuntimeMetaverse"/>
+    <property name="description" value="Creates execution profiles when jobs run"/>
+    <property name="pluginTypeInterface" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
+    <property name="category" value="Data Lineage"/>
+    <property name="classToBeanMap">
+      <map>
+        <entry key="org.pentaho.di.core.extension.ExtensionPointInterface" value="jobRuntime"/>
+        <entry key="org.pentaho.di.job.JobListener" value="jobRuntime"/>
+      </map>
+    </property>
+  </bean>
+  <service id="jobRuntimePluginService" interface="org.pentaho.di.core.plugins.PluginInterface" ref="jobRuntimePlugin">
+    <service-properties>
+      <entry key="PluginType" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
+    </service-properties>
+  </service>
 
 
   <!-- DI Repository config if ever needed/desired -->

--- a/core/src/main/resources/OSGI-INF/blueprint/pdi-plugins.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/pdi-plugins.xml
@@ -46,55 +46,7 @@
     </service-properties>
   </service>
 
-  <!-- TransRuntime extension point -->
-  <bean id="transRuntime" scope="singleton" class="org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransformationRuntimeExtensionPoint">
-    <property name="documentAnalyzer" ref="TransformationAnalyzer"/>
-    <property name="lineageWriter" ref="lineageWriter"/>
-  </bean>
-  <bean id="transRuntimePlugin" scope="singleton" class="org.pentaho.di.osgi.OSGIPlugin">
-    <property name="mainType" value="org.pentaho.di.core.extension.ExtensionPointInterface"/>
-    <property name="name" value="TransformationStartThreads"/>
-    <property name="ID" value="transRuntimeMetaverse"/>
-    <property name="description" value="Creates execution profiles when transformations run"/>
-    <property name="pluginTypeInterface" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
-    <property name="category" value="Data Lineage"/>
-    <property name="classToBeanMap">
-      <map>
-        <entry key="org.pentaho.di.core.extension.ExtensionPointInterface" value="transRuntime"/>
-        <entry key="org.pentaho.di.trans.TransListener" value="transRuntime"/>
-      </map>
-    </property>
-  </bean>
-  <service id="transRuntimePluginService" interface="org.pentaho.di.core.plugins.PluginInterface" ref="transRuntimePlugin">
-    <service-properties>
-      <entry key="PluginType" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
-    </service-properties>
-  </service>
 
-  <!-- JobRuntime extension point -->
-  <bean id="jobRuntime" scope="singleton" class="org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobRuntimeExtensionPoint">
-    <property name="documentAnalyzer" ref="JobAnalyzer"/>
-    <property name="lineageWriter" ref="lineageWriter"/>
-  </bean>
-  <bean id="jobRuntimePlugin" scope="singleton" class="org.pentaho.di.osgi.OSGIPlugin">
-    <property name="mainType" value="org.pentaho.di.core.extension.ExtensionPointInterface"/>
-    <property name="name" value="JobStart"/>
-    <property name="ID" value="jobRuntimeMetaverse"/>
-    <property name="description" value="Creates execution profiles when jobs run"/>
-    <property name="pluginTypeInterface" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
-    <property name="category" value="Data Lineage"/>
-    <property name="classToBeanMap">
-      <map>
-        <entry key="org.pentaho.di.core.extension.ExtensionPointInterface" value="jobRuntime"/>
-        <entry key="org.pentaho.di.job.JobListener" value="jobRuntime"/>
-      </map>
-    </property>
-  </bean>
-  <service id="jobRuntimePluginService" interface="org.pentaho.di.core.plugins.PluginInterface" ref="jobRuntimePlugin">
-    <service-properties>
-      <entry key="PluginType" value="org.pentaho.di.core.extension.ExtensionPointPluginType"/>
-    </service-properties>
-  </service>
 
   <!-- StepExternalResourceConsumerListener extension point -->
   <bean id="stepExternalResourceConsumerListener"

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobRuntimeExtensionPointTest.java
@@ -42,6 +42,7 @@ import org.pentaho.metaverse.api.model.IExecutionProfile;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -76,6 +77,7 @@ public class JobRuntimeExtensionPointTest {
   @Before
   public void setUp() throws Exception {
     jobExtensionPoint = new JobRuntimeExtensionPoint();
+    jobExtensionPoint.setRuntimeEnabled( true );
     jobMeta = spy( new JobMeta() );
     jobMeta.setName( TEST_JOB_NAME );
     jobMeta.setFilename( TEST_JOB_PATH );
@@ -129,6 +131,15 @@ public class JobRuntimeExtensionPointTest {
   public void testJobStarted() throws Exception {
     // Test jobStarted for coverage, it should do nothing
     jobExtensionPoint.jobStarted( null );
+  }
+
+  @Test
+  public void testRuntimeDisabled() throws Exception {
+    jobExtensionPoint.setRuntimeEnabled( false );
+    jobExtensionPoint.callExtensionPoint( null, job );
+    List<JobListener> listeners = job.getJobListeners();
+    assertNotNull( listeners );
+    assertFalse( listeners.contains( jobExtensionPoint ) );
   }
 
   private void createExecutionProfile( Job job ) {

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
@@ -30,6 +30,7 @@ import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.job.JobListener;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransListener;
 import org.pentaho.di.trans.TransMeta;
@@ -40,6 +41,7 @@ import org.pentaho.metaverse.api.model.IExecutionProfile;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -73,6 +75,7 @@ public class TransformationRuntimeExtensionPointTest {
   @Before
   public void setUp() throws Exception {
     transExtensionPoint = new TransformationRuntimeExtensionPoint();
+    transExtensionPoint.setRuntimeEnabled( true );
     lineageWriter = mock( ILineageWriter.class );
     transExtensionPoint.setLineageWriter( lineageWriter );
 
@@ -147,8 +150,17 @@ public class TransformationRuntimeExtensionPointTest {
   public void testPreviewTrans() throws Exception {
     TransformationRuntimeExtensionPoint ext = spy( transExtensionPoint );
     trans.setPreview( true );
-    ext.transStarted( trans );
+    ext.callExtensionPoint( null, trans );
     verify( ext, never() ).populateExecutionProfile(
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
+  }
+
+  @Test
+  public void testRuntimeDisabled() throws Exception {
+    transExtensionPoint.setRuntimeEnabled( false );
+    transExtensionPoint.callExtensionPoint( null, trans );
+    List<TransListener> listeners = trans.getTransListeners();
+    assertNotNull( listeners );
+    assertFalse( listeners.contains( transExtensionPoint ) );
   }
 }


### PR DESCRIPTION
Had to do a couple of things to get the runtime lineage fully disabled:

- Add the property as specified in BACKLOG-5180, along with setter methods (and unit tests)
- Move the check for "is preview or is disabled" to the TransRuntimeExtensionPoint callback, this prevents lineage from adding a Trans listener to collect lineage
- Changed the Lineage maps to use soft references for keys (using Guava's MapMaker), this prevents us from keeping Trans references around when they are finished (so they can be garbage collected, instead of causing a memory leak)
- Added/updated unit tests