### PR TITLE
[BACKLOG-5180][BACKLOG-5318] Fix Data Services auto-optimization and …

### DIFF
--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/TransformationAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/TransformationAnalyzer.java
@@ -94,6 +94,7 @@ public class TransformationAnalyzer extends BaseDocumentAnalyzer {
         String content = (String) repoObject;
         ByteArrayInputStream xmlStream = new ByteArrayInputStream( content.getBytes() );
         transMeta = new TransMeta( xmlStream, null, false, null, null );
+        transMeta.setFilename( document.getStringID() );
         if ( transMeta.hasMissingPlugins() ) {
           throw new MetaverseAnalyzerException( Messages.getErrorString( "ERROR.MissingPlugin" ) );
         }
@@ -104,9 +105,6 @@ public class TransformationAnalyzer extends BaseDocumentAnalyzer {
       transMeta = (TransMeta) repoObject;
     }
 
-    if ( transMeta.getRepository() == null ) {
-      transMeta.setFilename( document.getStringID() );
-    }
     Trans t = new Trans( transMeta );
     t.setInternalKettleVariables( transMeta );
 

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtil.java
@@ -51,11 +51,6 @@ public class TransExtensionPointUtil {
       throw new MetaverseException( Messages.getString( "ERROR.Document.IsNull" ) );
     }
 
-    // Don't analyze the transformation until it has been saved (i.e. has a filename)
-    if ( transMeta.getFilename() == null ) {
-      throw new MetaverseException( Messages.getString( "ERROR.Document.NotSaved" ) );
-    }
-
     // Get the "natural" filename (repo-based if in repository, filesystem-based otherwise)
     String filename = getFilename( transMeta );
 

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransOpenedExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransOpenedExtensionPoint.java
@@ -51,7 +51,8 @@ public class TransOpenedExtensionPoint implements ExtensionPointInterface {
 
     if ( object instanceof TransMeta ) {
       try {
-        TransExtensionPointUtil.addLineageGraph( (TransMeta) object );
+        TransMeta transMeta = (TransMeta) object;
+        TransExtensionPointUtil.addLineageGraph( transMeta );
       } catch ( MetaverseException me ) {
         if ( log != null && log.isDebug() ) {
           log.logDebug( Messages.getString( "ERROR.Graph.CouldNotCreate", me.getMessage() ) );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtilTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtilTest.java
@@ -29,9 +29,14 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.metaverse.api.IDocumentController;
+import org.pentaho.metaverse.api.IMetaverseObjectFactory;
 import org.pentaho.metaverse.api.MetaverseException;
+import org.pentaho.metaverse.testutils.MetaverseTestUtils;
+import org.pentaho.metaverse.util.MetaverseUtil;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
@@ -57,9 +62,14 @@ public class TransExtensionPointUtilTest {
     TransExtensionPointUtil.addLineageGraph( null );
   }
 
-  @Test( expected = MetaverseException.class )
+  @Test
   public void testAddLineageGraphNullFilename() throws Exception {
+    IDocumentController mockDoc = mock( IDocumentController.class );
+    IMetaverseObjectFactory factory = MetaverseTestUtils.getMetaverseObjectFactory();
+    when( mockDoc.getMetaverseObjectFactory() ).thenReturn( factory );
+    MetaverseUtil.setDocumentController( mockDoc );
     when( transMeta.getFilename() ).thenReturn( null );
+    when( transMeta.getPathAndName() ).thenReturn( "/Transformation 1" );
     TransExtensionPointUtil.addLineageGraph( transMeta );
   }
 }


### PR DESCRIPTION
…Exception during transformation save (backport of #391)

Approach is to add a Content Changed listener to each TransMeta, those callbacks are now responsible for updating the lineage graph. The original TransChangedExtensionPoint now simply adds the Content Changed listener if it has not yet been added.

This allows Lineage to be created after a new transformation has been saved. This enables Data Services to retrieve the correct Lineage graph, which gives the correct auto-optimizations (BACKLOG-5180).

Moved the "setFilename()" call into the "metaverse proper" code, which is the code path used when collecting static lineage from a repository (which is currently disabled). If the transMeta.getFilename() is null, it will fall back to transMeta.getPathAndName(), which is set even on new transformations. This removes the regression in BACKLOG-5318.

@dkincade Please review at your earliest convenience, thanks!