### PR TITLE
[SP-2656] Backport of PDI-14959 - Data Lineage: Table Output step analyzer does not add default fields to the lineage output (6.1 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -113,10 +113,22 @@ public class TableOutputStepAnalyzer extends ConnectionExternalResourceStepAnaly
 
     return outputRows;
   }
-
+  /**
+   * Get the resource fields actually written to the table. Normally return fields specified in table settings.
+   * If no fields specified and "specify database fields" option is unchecked, return regular output fields.
+   *
+   * @param meta Table Output component metadata
+   * @return set of resource field names
+   */
   @Override
   public Set<String> getOutputResourceFields( TableOutputMeta meta ) {
-    Set<String> fields = new LinkedHashSet<>( Arrays.asList( meta.getFieldDatabase() ) );
+    String[] fieldArray = meta.getFieldDatabase();
+    // !meta.specifyFields() condition can be removed if necessary since it is some kind of overhead --Kaa
+    // Additional info: http://jira.pentaho.com/browse/PDI-14959
+    if ( ArrayUtils.isEmpty( fieldArray ) && !meta.specifyFields() ) {
+      fieldArray = getOutputFields( meta ).getFieldNames();
+    }
+    Set<String> fields = new LinkedHashSet<>( Arrays.asList( fieldArray ) );
     return fields;
   }
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -233,6 +233,35 @@ public class TableOutputStepAnalyzerTest {
     for ( String outputField : outputFields ) {
       assertTrue( outputResourceFields.contains( outputField ) );
     }
+  }
+  /**
+   * Test case for http://jira.pentaho.com/browse/PDI-14959 issue.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testGetOutputResourceFieldsWithoutSpecifiedFields() throws Exception {
+    String[] outputFields = new String[2];
+    outputFields[0] = "fieldA";
+    outputFields[1] = "fieldB";
+    RowMetaInterface rmi = mock( RowMetaInterface.class );
+
+    when( meta.getFieldDatabase() ).thenReturn( new String[0] );
+    when( meta.specifyFields() ).thenReturn( Boolean.FALSE );
+    when( rmi.getFieldNames() ).thenReturn( outputFields );
+
+    doReturn( rmi ).when( analyzer ).getOutputFields( meta );
+
+    Set<String> outputResourceFields = analyzer.getOutputResourceFields( meta );
+
+    assertEquals( outputFields.length, outputResourceFields.size() );
+    for ( String outputField : outputFields ) {
+      assertTrue( outputResourceFields.contains( outputField ) );
+    }
+
+    when( meta.specifyFields() ).thenReturn( Boolean.TRUE );
+    outputResourceFields = analyzer.getOutputResourceFields( meta );
+    assertEquals( 0, outputResourceFields.size() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/transexecutor/TransExecutorStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/transexecutor/TransExecutorStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *


### PR DESCRIPTION
Backport