### PR TITLE
[BACKLOG-21736] Adding input files for the case when JSON Input step file name is expressed in a field

### DIFF
--- a/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
@@ -1,0 +1,42 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.api;
+
+public interface IMetaverseConfig {
+
+  void setExecutionRuntime( final String executionRuntime );
+
+  String getExecutionOutputFolder();
+
+  void setExecutionOutputFolder( final String executionOutputFolder );
+
+  String getExecutionRuntime();
+
+  void setExecutionGenerationStrategy( final String executionGenerationStrategy );
+
+  String getExecutionGenerationStrategy();
+
+  void setResolveExternalResources( final boolean resolveExternalResources );
+
+  boolean getResolveExternalResources();
+}

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
@@ -47,8 +47,8 @@ import java.util.LinkedList;
 public class KettleAnalyzerUtil {
 
   /**
-   * Utility method for normalizing file paths used in Metaverse Id generation. It will convert a valid path
-   * into a consistent path regardless of URI notation or filesystem absolute path.
+   * Utility method for normalizing file paths used in Metaverse Id generation. It will convert a valid path into a
+   * consistent path regardless of URI notation or filesystem absolute path.
    *
    * @param filePath full path to normalize
    * @return the normalized path
@@ -117,9 +117,10 @@ public class KettleAnalyzerUtil {
     }
 
     try {
-      String filename = meta == null ? null : rowMeta.getString( row, meta.getAcceptingField(), null );
+      String filename = meta == null ? null : step.environmentSubstitute(
+        rowMeta.getString( row, meta.getAcceptingField(), null ) );
       if ( !Const.isEmpty( filename ) ) {
-        FileObject fileObject = KettleVFS.getFileObject( filename );
+        FileObject fileObject = KettleVFS.getFileObject( filename, step );
         resources.add( ExternalResourceInfoFactory.createFileResource( fileObject, true ) );
       }
     } catch ( KettleException kve ) {

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzer.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzer.java
@@ -59,7 +59,7 @@ public abstract class ExternalResourceStepAnalyzer<T extends BaseStepMeta> exten
     // handle all of the external resources
     if ( getExternalResourceConsumer() != null ) {
       IAnalysisContext context = getDescriptor().getContext();
-      Collection<IExternalResourceInfo> resources = getExternalResourceConsumer().getResourcesFromMeta( meta, context );
+      Collection<IExternalResourceInfo> resources = getExternalResourceConsumer().getResources( meta, context );
       for ( IExternalResourceInfo resource : resources ) {
         try {
           if ( resource.isInput() ) {

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/IStepExternalResourceConsumer.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/IStepExternalResourceConsumer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,10 +25,12 @@ package org.pentaho.metaverse.api.analyzer.kettle.step;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.metaverse.api.IAnalysisContext;
 import org.pentaho.metaverse.api.analyzer.kettle.IExternalResourceConsumer;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * IStepExternalResourceConsumer is a helper interface used by ExternalResourceConsumer plugins that handle a single
@@ -40,4 +42,8 @@ public interface IStepExternalResourceConsumer<S extends BaseStep, M extends Bas
   extends IExternalResourceConsumer<M> {
 
   Collection<IExternalResourceInfo> getResourcesFromRow( S consumer, RowMetaInterface rowMeta, Object[] row );
+
+  default Collection<IExternalResourceInfo> getResources( final M meta, final IAnalysisContext context ) {
+    return Collections.emptyList();
+  }
 }

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzer.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzer.java
@@ -571,11 +571,7 @@ public abstract class StepAnalyzer<T extends BaseStepMeta> extends BaseKettleMet
         RowMetaInterface rmi = parentTransMeta.getPrevStepFields( parentStepMeta, progressMonitor );
         progressMonitor.done();
         if ( !ArrayUtils.isEmpty( prevStepNames ) ) {
-          // get input fields from all previous steps, not just the first one
-          for ( int i = 0; i < prevStepNames.length; i++ ) {
-            rowMeta.put( prevStepNames[i], rmi );
-          }
-
+          rowMeta.put( prevStepNames[0], rmi );
         }
       } catch ( KettleStepException e ) {
         rowMeta = null;

--- a/api/src/main/java/org/pentaho/metaverse/api/model/BaseResourceInfo.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/model/BaseResourceInfo.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,8 @@
 package org.pentaho.metaverse.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,4 +69,26 @@ public class BaseResourceInfo extends BaseInfo implements IExternalResourceInfo 
     attributes.put( key, value );
   }
 
+  @Override
+  public boolean equals( final Object obj ) {
+    if ( obj == null ) {
+      return false;
+    }
+    if ( obj == this ) {
+      return true;
+    }
+    if ( obj.getClass() != getClass() ) {
+      return false;
+    }
+    final BaseResourceInfo info = (BaseResourceInfo) obj;
+    return new EqualsBuilder().append( getName(), info.getName() ).append( getDescription(), info.getDescription() )
+      .append( getType(), info.getType() ).append( isInput(), info.isInput() )
+      .append( getAttributes(), info.getAttributes() ).isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder( 17, 37 ).append( getName() ).append( getDescription() ).append( getType() )
+      .append( isInput() ).append( getAttributes() ).toHashCode();
+  }
 }

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ConnectionExternalResourceStepAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ConnectionExternalResourceStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -134,6 +134,7 @@ public class ConnectionExternalResourceStepAnalyzerTest {
     doReturn( connectionNode ).when( analyzer ).getConnectionNode();
 
     doReturn( resourceNode ).when( analyzer ).createResourceNode( any( IExternalResourceInfo.class ) );
+    when( erc.getResources( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
 
     analyzer.customAnalyze( meta, node );
 

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzerTest.java
@@ -129,7 +129,7 @@ public class ExternalResourceStepAnalyzerTest {
     resources.add( resInfo );
     when( resInfo.isInput() ).thenReturn( true );
 
-    when( erc.getResourcesFromMeta( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
+    when( erc.getResources( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
 
     analyzer.customAnalyze( meta, node );
 
@@ -149,7 +149,7 @@ public class ExternalResourceStepAnalyzerTest {
     when( resInfo.isInput() ).thenReturn( false );
     when( resInfo.isOutput() ).thenReturn( true );
 
-    when( erc.getResourcesFromMeta( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
+    when( erc.getResources( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
 
     analyzer.customAnalyze( meta, node );
 

--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -82,7 +82,6 @@ import org.pentaho.metaverse.frames.FileInputStepNode;
 import org.pentaho.metaverse.frames.FilterRowsStepNode;
 import org.pentaho.metaverse.frames.FixedFileInputStepNode;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
-import org.pentaho.metaverse.frames.GetXMLDataStepNode;
 import org.pentaho.metaverse.frames.GroupByStepNode;
 import org.pentaho.metaverse.frames.HttpClientStepNode;
 import org.pentaho.metaverse.frames.HttpPostStepNode;
@@ -106,7 +105,6 @@ import org.pentaho.metaverse.frames.TextFileOutputStepNode;
 import org.pentaho.metaverse.frames.TransExecutorStepNode;
 import org.pentaho.metaverse.frames.TransformationNode;
 import org.pentaho.metaverse.frames.TransformationStepNode;
-import org.pentaho.metaverse.frames.XMLOutputStepNode;
 import org.pentaho.metaverse.locator.FileSystemLocator;
 import org.pentaho.metaverse.util.MetaverseUtil;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -169,6 +167,13 @@ public class MetaverseValidationIT {
   @Before
   public void setUp() throws Exception {
 
+  }
+
+  private String normalizeFilePath( final String tilePath ) {
+    if ( StringUtils.isBlank( tilePath ) ) {
+      return tilePath;
+    }
+    return tilePath.replace( "file://", "" ).replace( "/C:", "C:" ).replace( "\\", "/" );
   }
 
   @Test
@@ -747,7 +752,7 @@ public class MetaverseValidationIT {
     assertEquals( fileNames.length, getIterableSize( outputFiles ) );
     int i = 0;
     for ( FramedMetaverseNode node : outputFiles ) {
-      assertEquals( fileNames[i++].replace( "file://", "" ), node.getName() );
+      assertEquals( normalizeFilePath( fileNames[i++] ),normalizeFilePath(  node.getName() ) );
     }
 
     Iterable<StreamFieldNode> outFields = textFileOutputStepNode.getOutputStreamFields();
@@ -1010,7 +1015,7 @@ public class MetaverseValidationIT {
     assertEquals( fileNames.length, getIterableSize( outputFiles ) );
     int i = 0;
     for ( FramedMetaverseNode node : outputFiles ) {
-      assertEquals( fileNames[i++].replace( "file://", "" ), node.getName() );
+      assertEquals( normalizeFilePath( fileNames[i++] ), normalizeFilePath( node.getName() ) );
     }
 
     Iterable<StreamFieldNode> outFields = excelOutputStepNode.getOutputStreamFields();

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.Result;
@@ -112,7 +113,10 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
    */
   @Override
   public void transStarted( Trans trans ) throws KettleException {
+    // no-op, we wait to kick off the analyzer until the transformation is finished executing
+  }
 
+  protected void startAnalyzer( Trans trans ) throws KettleException {
     if ( trans == null ) {
       return;
     }
@@ -267,6 +271,8 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
     if ( trans == null ) {
       return;
     }
+
+    startAnalyzer( trans );
 
     if ( trans.isPreview() ) {
       return;

--- a/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
@@ -1,0 +1,68 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.impl;
+
+import org.pentaho.metaverse.api.IMetaverseConfig;
+
+/**
+ * A single point of access for all metaverse osgi configuration properties.
+ */
+public class MetaverseConfig implements IMetaverseConfig {
+
+  private String executionRuntime = "off";
+  private String extecutionOutputFolder = "./pentaho-lineage-output";
+  private String executionGenerationStrategy = "latest";
+  private boolean resolveExternalResources = false;
+
+  public void setExecutionRuntime( final String executionRuntime ) {
+    this.executionRuntime = executionRuntime;
+  }
+
+  public String getExecutionRuntime() {
+    return this.executionRuntime;
+  }
+
+  public void setExecutionOutputFolder( final String extecutionOutputFolder ) {
+    this.extecutionOutputFolder = extecutionOutputFolder;
+  }
+
+  public String getExecutionOutputFolder() {
+    return this.extecutionOutputFolder;
+  }
+
+  public void setExecutionGenerationStrategy( final String executionGenerationStrategy ) {
+    this.executionGenerationStrategy = executionGenerationStrategy;
+  }
+
+  public String getExecutionGenerationStrategy() {
+    return this.executionGenerationStrategy;
+  }
+
+  public void setResolveExternalResources( final boolean resolveExternalResources ) {
+    this.resolveExternalResources = resolveExternalResources;
+  }
+
+  public boolean getResolveExternalResources() {
+    return this.resolveExternalResources;
+  }
+}

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,6 +13,7 @@
       <cm:property name="lineage.execution.runtime" value="off"/>
       <cm:property name="lineage.execution.output.folder" value="./pentaho-lineage-output"/>
       <cm:property name="lineage.execution.generation.strategy" value="latest"/>
+      <cm:property name="lineage.resolve.external.resources" value="false"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -25,6 +26,15 @@
       </map>
     </argument>
   </bean>
+
+  <!-- A single point of access for all metaverse osgi config properties -->
+  <bean id="metaverseConfig" class="org.pentaho.metaverse.impl.MetaverseConfig" scope="singleton">
+    <property name="executionRuntime" value="${lineage.execution.runtime}"/>
+    <property name="executionOutputFolder" value="${lineage.execution.output.folder}"/>
+    <property name="executionGenerationStrategy" value="${lineage.execution.generation.strategy}"/>
+    <property name="resolveExternalResources" value="${lineage.resolve.external.resources}"/>
+  </bean>
+  <service id="metaverseConfigService" interface="org.pentaho.metaverse.api.IMetaverseConfig" ref="metaverseConfig"/>
 
   <bean id="MetaverseGraphImplPrototype" class="org.pentaho.metaverse.graph.SynchronizedGraphFactory" factory-method="open" scope="prototype">
     <argument>


### PR DESCRIPTION
Also adding the "lineage.resolve.external.resources" config property for the metaverse osgi plugin and fixing some metaverse integration tests that were failing on windows.

Related pentaho-kettle PR: https://github.com/pentaho/pentaho-kettle/pull/5154

@pentaho/r2d2 