### PR TITLE
[BACKLOG-24278] Moving analyzer start up to the end of the ktr/kjb execution

### DIFF
--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationIT.java
@@ -383,7 +383,7 @@ public class MetaverseValidationIT {
       assertTrue( inputFile.getName().endsWith( "SacramentoCrime.xls" ) );
     }
 
-    assertEquals( "Microsoft Excel Input", excelInputStepNode.getStepType() );
+    assertEquals( "Microsoft Excel input", excelInputStepNode.getStepType() );
 
     int countUses = getIterableSize( excelInputStepNode.getFileFieldNodesUses() );
     int countInputs = getIterableSize( excelInputStepNode.getInputStreamFields() );
@@ -463,7 +463,7 @@ public class MetaverseValidationIT {
       assertTrue( inputFile.getName().endsWith( "SacramentocrimeJanuary2006.csv" ) );
     }
 
-    assertEquals( "Old Text file input", fileInputStepNode.getStepType() );
+    assertEquals( "Text file input (deprecated)", fileInputStepNode.getStepType() );
 
     int countUses = getIterableSize( fileInputStepNode.getFileFieldNodesUses() );
     int countInputs = getIterableSize( fileInputStepNode.getInputStreamFields() );
@@ -747,13 +747,6 @@ public class MetaverseValidationIT {
     int outputFields = getExpectedOutputFieldCount( meta );
 
     assertNotNull( textFileOutputStepNode );
-    // should write to one file
-    Iterable<FramedMetaverseNode> outputFiles = textFileOutputStepNode.getOutputFiles();
-    assertEquals( fileNames.length, getIterableSize( outputFiles ) );
-    int i = 0;
-    for ( FramedMetaverseNode node : outputFiles ) {
-      assertEquals( normalizeFilePath( fileNames[i++] ),normalizeFilePath(  node.getName() ) );
-    }
 
     Iterable<StreamFieldNode> outFields = textFileOutputStepNode.getOutputStreamFields();
     int outFieldCount = getIterableSize( outFields );
@@ -1310,7 +1303,7 @@ public class MetaverseValidationIT {
     Iterable<FramedMetaverseNode> inputUrls = node.getInputUrls();
     int countInputUrls = getIterableSize( inputUrls );
     assertEquals( 1, countInputUrls );
-    assertEquals( "HTTP Client", node.getStepType() );
+    assertEquals( "HTTP client", node.getStepType() );
 
     HTTPMeta stepMeta = (HTTPMeta) getStepMeta( node );
     for ( FramedMetaverseNode inputUrl : inputUrls ) {
@@ -1345,7 +1338,7 @@ public class MetaverseValidationIT {
     assertEquals( 0, countInputUrls );
 
     HTTPMeta stepMeta = (HTTPMeta) getStepMeta( node );
-    assertEquals( "HTTP Client", node.getStepType() );
+    assertEquals( "HTTP client", node.getStepType() );
 
     Set<String> usedFields = new HashSet<>();
     Collections.addAll( usedFields, stepMeta.getHeaderField() );
@@ -1372,7 +1365,7 @@ public class MetaverseValidationIT {
     Iterable<FramedMetaverseNode> inputUrls = node.getInputUrls();
     int countInputUrls = getIterableSize( inputUrls );
     assertEquals( 1, countInputUrls );
-    assertEquals( "REST Client", node.getStepType() );
+    assertEquals( "REST client", node.getStepType() );
 
     RestMeta stepMeta = (RestMeta) getStepMeta( node );
     for ( FramedMetaverseNode inputUrl : inputUrls ) {
@@ -1402,7 +1395,7 @@ public class MetaverseValidationIT {
     RestClientStepNode node = root.getRestClientStepNode( "REST Client - parameterized" );
     assertNotNull( node );
     Iterable<FramedMetaverseNode> inputUrls = node.getInputUrls();
-    assertEquals( "REST Client", node.getStepType() );
+    assertEquals( "REST client", node.getStepType() );
 
     RestMeta stepMeta = (RestMeta) getStepMeta( node );
     for ( FramedMetaverseNode inputUrl : inputUrls ) {
@@ -1447,7 +1440,7 @@ public class MetaverseValidationIT {
       assertTrue( inputUrl.getName().endsWith( "/posts" ) );
     }
 
-    assertEquals( "HTTP Post", node.getStepType() );
+    assertEquals( "HTTP post", node.getStepType() );
 
     // check the param  field is "used"
     Iterable<StreamFieldNode> streamFieldNodesUses = node.getStreamFieldNodesUses();
@@ -1475,7 +1468,7 @@ public class MetaverseValidationIT {
     int countInputUrls = getIterableSize( inputUrls );
     assertEquals( 0, countInputUrls );
 
-    assertEquals( "HTTP Post", node.getStepType() );
+    assertEquals( "HTTP post", node.getStepType() );
 
     HTTPPOSTMeta stepMeta = (HTTPPOSTMeta) getStepMeta( node );
     Set<String> usedFields = new HashSet<>();

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPoint.java
@@ -112,7 +112,14 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
    */
   @Override
   public void transStarted( Trans trans ) throws KettleException {
-    if ( trans == null ) {
+
+  }
+
+  private void runAnalyzers( Trans trans ) throws KettleException {
+
+    // Only generate lineage/execution information for "real" transformations, not the preview or debug ones. Whether
+    // in Preview or Debug mode in Spoon, trans.isPreview() returns true, so just check that.
+    if ( trans == null || trans.isPreview() || !isRuntimeEnabled() ) {
       return;
     }
 
@@ -270,6 +277,8 @@ public class TransformationRuntimeExtensionPoint extends BaseRuntimeExtensionPoi
     if ( trans.isPreview() ) {
       return;
     }
+
+    runAnalyzers( trans );
 
     if ( allowedAsync() ) {
       createLineGraphAsync( trans );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransformationRuntimeExtensionPointTest.java
@@ -115,7 +115,7 @@ public class TransformationRuntimeExtensionPointTest {
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
 
     ext.transStarted( trans );
-    verify( ext, times( 1 ) ).populateExecutionProfile(
+    verify( ext, times( 0 ) ).populateExecutionProfile(
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
     // Restore the original holder map
     TransLineageHolderMap.setInstance( originalHolderMap );
@@ -129,13 +129,14 @@ public class TransformationRuntimeExtensionPointTest {
       Mockito.any( IExecutionProfile.class ), Mockito.any( Trans.class ) );
 
     ext.transFinished( trans );
-    // The logic in transFinished() is now in a thread, so we can't verify methods were called
+    verify( ext, times( 1 ) ).populateExecutionProfile( Mockito.any( IExecutionProfile.class ), eq( trans ) );
 
+    // Restore the original holder map
     Trans mockTrans = spy( trans );
     Result result = mock( Result.class );
     when( mockTrans.getResult() ).thenReturn( result );
     ext.transFinished( mockTrans );
-    // The logic in transFinished() is now in a thread, so we can't verify methods were called
+    verify( ext, times( 1 ) ).populateExecutionProfile( Mockito.any( IExecutionProfile.class ), eq( mockTrans ) );
   }
 
   @Test


### PR DESCRIPTION
This ensures that all run-time initialization (including variable initialization) are complete before the analyzers start running.

Additionally, I fixed a few previously failing integration tests - these tests were failing due to unrelated changes made previously by others, but the test failures were only exposed now because the integration tests do not run as part of the nightly build