### PR TITLE
[BACKLOG-25381] Adding field level lineage support for file fields to IGC

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${dependency.com.fasterxml.jackson.core.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-configuration</groupId>

--- a/api/src/main/java/org/pentaho/dictionary/DictionaryConst.java
+++ b/api/src/main/java/org/pentaho/dictionary/DictionaryConst.java
@@ -41,6 +41,26 @@ public class DictionaryConst {
 
 
   /**
+   * Property key for "stepType".
+   */
+  public static final String PROPERTY_STEP_TYPE = "stepType";
+
+  /**
+   * Property key for "jobEntryType".
+   */
+  public static final String PROPERTY_JOB_ENTRY_TYPE = "jobEntryType";
+
+  /**
+   * Property key for "copies".
+   */
+  public static final String PROPERTY_COPIES = "copies";
+
+  /**
+   * Property key for "_analyzer".
+   */
+  public static final String PROPERTY_ANALYZER = "_analyzer";
+
+  /**
    * Property key for "pluginId".
    */
   public static final String PROPERTY_PLUGIN_ID = "pluginId";
@@ -403,6 +423,11 @@ public class DictionaryConst {
    * The node type for SQL Queries
    */
   public static final String NODE_TYPE_SQL_QUERY = "SQL Query";
+
+  /**
+   * The name assigned to nodes representing SQL queries.
+   */
+  public static final String NODE_NAME_SQL = "SQL";
 
   /**
    * The node type for PDI transformation fields

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/jobentry/JobEntryAnalyzer.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/jobentry/JobEntryAnalyzer.java
@@ -106,10 +106,10 @@ public abstract class JobEntryAnalyzer<T extends JobEntryInterface> extends Base
       stepType = entry.getClass().getSimpleName();
     }
     rootNode.setProperty( DictionaryConst.PROPERTY_PLUGIN_ID, entry.getPluginId() );
-    rootNode.setProperty( "jobEntryType", stepType );
-    rootNode.setProperty( "copies", entry.getParentJob().getJobMeta().getJobCopies().size() );
-    rootNode.setProperty( "description", entry.getDescription() );
-    rootNode.setProperty( "_analyzer", this.getClass().getSimpleName() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_JOB_ENTRY_TYPE, stepType );
+    rootNode.setProperty( DictionaryConst.PROPERTY_COPIES, entry.getParentJob().getJobMeta().getJobCopies().size() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_DESCRIPTION, entry.getDescription() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_ANALYZER, this.getClass().getSimpleName() );
     metaverseBuilder.addNode( rootNode );
 
     customAnalyze( entry, rootNode );

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzer.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzer.java
@@ -127,10 +127,10 @@ public abstract class StepAnalyzer<T extends BaseStepMeta> extends BaseKettleMet
       stepType = parentStepMeta.getStepID();
     }
     rootNode.setProperty( DictionaryConst.PROPERTY_PLUGIN_ID, parentStepMeta.getStepID() );
-    rootNode.setProperty( "stepType", stepType );
-    rootNode.setProperty( "copies", meta.getParentStepMeta().getCopies() );
-    rootNode.setProperty( "_analyzer", this.getClass().getSimpleName() );
-    rootNode.setProperty( "description", parentStepMeta.getDescription() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_STEP_TYPE, stepType );
+    rootNode.setProperty( DictionaryConst.PROPERTY_COPIES, meta.getParentStepMeta().getCopies() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_ANALYZER, this.getClass().getSimpleName() );
+    rootNode.setProperty( DictionaryConst.PROPERTY_DESCRIPTION, parentStepMeta.getDescription() );
     metaverseBuilder.addNode( rootNode );
 
     inputs = processInputs( meta );
@@ -583,13 +583,22 @@ public abstract class StepAnalyzer<T extends BaseStepMeta> extends BaseKettleMet
         RowMetaInterface rmi = parentTransMeta.getPrevStepFields( parentStepMeta, progressMonitor );
         progressMonitor.done();
         if ( !ArrayUtils.isEmpty( prevStepNames ) ) {
-          rowMeta.put( prevStepNames[ 0 ], rmi );
+          populateInputFieldsRowMeta( rowMeta, rmi );
         }
       } catch ( KettleStepException e ) {
         rowMeta = null;
       }
     }
     return rowMeta;
+  }
+
+  /**
+   * Populates the {@code rowMeta} with data from all input steps, can be overridden to do otherwise.
+   */
+  protected void populateInputFieldsRowMeta( final Map<String, RowMetaInterface> rowMeta, final RowMetaInterface rmi ) {
+    for ( final String previousStepName : prevStepNames ) {
+      rowMeta.put( previousStepName, rmi );
+    }
   }
 
   @Override

--- a/api/src/main/java/org/pentaho/metaverse/api/model/BaseMetaverseBuilder.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/model/BaseMetaverseBuilder.java
@@ -135,7 +135,7 @@ public class BaseMetaverseBuilder extends MetaverseObjectFactory implements IMet
    * @param toVertex   the target vertex
    * @return the String edge ID
    */
-  public String getEdgeId( Vertex fromVertex, String label, Vertex toVertex ) {
+  public static String getEdgeId( Vertex fromVertex, String label, Vertex toVertex ) {
     return fromVertex.getId() + SEPARATOR + label + SEPARATOR + toVertex.getId();
   }
 

--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDedupIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDedupIT.java
@@ -1,0 +1,75 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.pentaho.metaverse.frames.FramedMetaverseNode;
+import org.pentaho.metaverse.impl.MetaverseConfig;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Runs the integration test with the {@link MetaverseConfig} mocked to have the {@code deduplicateTransformationFields}
+ * and {@code adjustExternalResourceFields} variables set to true, to force the graph to be adjusted.
+ */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( MetaverseConfig.class )
+public class MetaverseValidationDedupIT extends MetaverseValidationIT {
+
+  @BeforeClass
+  public static void init() throws Exception {
+
+    PowerMockito.mockStatic( MetaverseConfig.class );
+    Mockito.when( MetaverseConfig.adjustExternalResourceFields() ).thenReturn( true );
+    Mockito.when( MetaverseConfig.deduplicateTransformationFields() ).thenReturn( true );
+
+    MetaverseValidationIT.init();
+  }
+
+  @Test
+  public void testSelectValuesStep() throws Exception {
+    testSelectValuesStep( 8 );
+  }
+
+  @Test
+  public void testTextFileInputNode() throws Exception {
+    List<FramedMetaverseNode> containedNodes = testTextFileInputNodeImpl( 3 );
+    // get field names
+    List<String> nodeNames = new ArrayList();
+    for ( final FramedMetaverseNode node : containedNodes ) {
+      nodeNames.add( node.getName() );
+    }
+    Assert.assertTrue( nodeNames.contains( "longitude" ) );
+    Assert.assertTrue( nodeNames.contains( "latitude" ) );
+    Assert.assertTrue( nodeNames.contains( "address" ) );
+  }
+}

--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDefaultIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDefaultIT.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -20,22 +20,28 @@
  *
  ******************************************************************************/
 
-package org.pentaho.metaverse.graph;
+package org.pentaho.metaverse;
 
-import com.tinkerpop.blueprints.Graph;
-
-import java.io.IOException;
-import java.io.OutputStream;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
- * The GraphSONWriter class contains methods for writing a metaverse graph model in GraphSON format
- * 
+ * Runs the integration tests with the details configuration (no field deduplication).
  */
-public class GraphSONWriter extends BaseGraphWriter {
+public class MetaverseValidationDefaultIT extends MetaverseValidationIT {
 
-  @Override
-  public void outputGraphImpl( Graph graph, OutputStream graphSONOutputStream ) throws IOException {
-    com.tinkerpop.blueprints.util.io.graphson.GraphSONWriter.outputGraph( graph, graphSONOutputStream );
+  @BeforeClass
+  public static void init() throws Exception {
+    MetaverseValidationIT.init();
   }
 
+  @Test
+  public void testSelectValuesStep() throws Exception {
+    testSelectValuesStep( 16 );
+  }
+
+  @Test
+  public void testTextFileInputNode() throws Exception {
+    testTextFileInputNodeImpl( 0 );
+  }
 }

--- a/core/src/it/java/org/pentaho/metaverse/frames/FramedMetaverseNode.java
+++ b/core/src/it/java/org/pentaho/metaverse/frames/FramedMetaverseNode.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,8 @@
 
 package org.pentaho.metaverse.frames;
 
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import org.pentaho.dictionary.DictionaryConst;
 
@@ -40,4 +42,7 @@ public interface FramedMetaverseNode {
 
   @Property( DictionaryConst.PROPERTY_DESCRIPTION )
   String getDescription();
+
+  @Adjacency( label = "contains", direction = Direction.OUT )
+  Iterable<StreamFieldNode> getContainedNodes();
 }

--- a/core/src/it/java/org/pentaho/metaverse/frames/RootNode.java
+++ b/core/src/it/java/org/pentaho/metaverse/frames/RootNode.java
@@ -81,8 +81,17 @@ public interface RootNode extends FramedMetaverseNode {
   @GremlinGroovy( "it.out.has('name', T.eq, 'External Connection').out.has('name', T.eq, 'Database Connection').out('typeconcept').has('name', T.eq, name)" )
   DatasourceNode getDatasourceNode( @GremlinParam( "name" ) String name );
 
-  @GremlinGroovy( "it.out.has('name', T.eq, 'Transformation').out.has('name', T.eq, 'Transformation Step').out('typeconcept').has('name', T.eq, 'Demo table crime stats output').as('step').in('contains').has('name', T.eq, 'Populate Table From File').back('step')" )
-  TableOutputStepNode getTableOutputStepNode();
+  @GremlinGroovy( "it.out.has('name', T.eq, 'Transformation').out.has('name', T.eq, 'Transformation Step').out('typeconcept').has('name', T.eq, 'Sacramento crime stats 2006 file').as('step').in('contains').has('name', T"
+    + ".eq, 'Populate Table From File').back('step')" )
+  TextFileInputNode getTextFileInputNode();
+
+  @GremlinGroovy( "it.out.has('name', T.eq, 'Transformation').out.has('name', T.eq, 'Transformation Step').out('typeconcept').has('name', T.eq, 'Demo table crime stats output [1]').as('step').in('contains').has('name', T"
+    + ".eq, 'Populate Table From File').back('step')" )
+  TableOutputStepNode getTableOutputStepNode1();
+
+  @GremlinGroovy( "it.out.has('name', T.eq, 'Transformation').out.has('name', T.eq, 'Transformation Step').out('typeconcept').has('name', T.eq, 'Demo table crime stats output [2]').as('step').in('contains').has('name', T"
+    + ".eq, 'Populate Table From File').back('step')" )
+  TableOutputStepNode getTableOutputStepNode2();
 
   @GremlinGroovy( "it.out.has('name', T.eq, 'Transformation').out.has('name', T.eq, 'Transformation Step').out('typeconcept').has('name', T.eq, 'Table input').as('step').in('contains').has('name', T.eq, 'merge_join').back('step')" )
   TableInputStepNode getTableInputStepNode();

--- a/core/src/it/java/org/pentaho/metaverse/frames/TextFileInputNode.java
+++ b/core/src/it/java/org/pentaho/metaverse/frames/TextFileInputNode.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -20,22 +20,14 @@
  *
  ******************************************************************************/
 
-package org.pentaho.metaverse.graph;
+package org.pentaho.metaverse.frames;
 
-import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.Adjacency;
 
-import java.io.IOException;
-import java.io.OutputStream;
+public interface TextFileInputNode extends TransformationStepNode {
 
-/**
- * The GraphSONWriter class contains methods for writing a metaverse graph model in GraphSON format
- * 
- */
-public class GraphSONWriter extends BaseGraphWriter {
-
-  @Override
-  public void outputGraphImpl( Graph graph, OutputStream graphSONOutputStream ) throws IOException {
-    com.tinkerpop.blueprints.util.io.graphson.GraphSONWriter.outputGraph( graph, graphSONOutputStream );
-  }
+  @Adjacency( label = "isreadby", direction = Direction.IN )
+  Iterable<FramedMetaverseNode> getInputFiles();
 
 }

--- a/core/src/it/resources/repo/validation/file_to_table.ktr
+++ b/core/src/it/resources/repo/validation/file_to_table.ktr
@@ -7,7 +7,7 @@
     <trans_version>1.0</trans_version>
     <trans_type>Normal</trans_type>
     <trans_status>2</trans_status>
-    <directory>&#x2f;</directory>
+    <directory>/</directory>
     <parameters>
       <parameter>
         <name>testTransParam1</name>
@@ -438,9 +438,11 @@
     <clusterschemas>
     </clusterschemas>
     <created_user>gmoran</created_user>
-    <created_date>2014&#x2f;08&#x2f;12 14&#x3a;30&#x3a;43.221</created_date>
+    <created_date>2014/08/12 14:30:43.221</created_date>
     <modified_user>rfellows</modified_user>
-    <modified_date>2014&#x2f;08&#x2f;12 14&#x3a;30&#x3a;43.221</modified_date>
+    <modified_date>2014/08/12 14:30:43.221</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
   </info>
   <notepads>
   </notepads>
@@ -452,7 +454,7 @@
     <database>sampledata</database>
     <port>-1</port>
     <username>sa</username>
-    <password>Encrypted</password>
+    <password>Encrypted 2be98afc86aa7f2a1a51abc69ce86aade</password>
     <servername/>
     <data_tablespace/>
     <index_tablespace/>
@@ -497,18 +499,23 @@
   </connection>
   <order>
     <hop>
+      <from>Select values</from>
+      <to>Demo table crime stats output [1]</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
       <from>Sacramento crime stats 2006 file</from>
       <to>Select values</to>
       <enabled>Y</enabled>
     </hop>
     <hop>
       <from>Select values</from>
-      <to>Demo table crime stats output</to>
+      <to>Demo table crime stats output [2]</to>
       <enabled>Y</enabled>
     </hop>
   </order>
   <step>
-    <name>Demo table crime stats output</name>
+    <name>Demo table crime stats output [1]</name>
     <type>TableOutput</type>
     <description/>
     <distribute>Y</distribute>
@@ -520,7 +527,7 @@
     </partitioning>
     <connection>Sampledata</connection>
     <schema/>
-    <table>&#x24;&#x7b;testTransParam3&#x7d;</table>
+    <table>${testTransParam1}</table>
     <commit>1000</commit>
     <truncate>N</truncate>
     <ignore_errors>N</ignore_errors>
@@ -571,19 +578,95 @@
     </fields>
     <cluster_schema/>
     <remotesteps>
-      <input></input>
-      <output></output>
+      <input>
+      </input>
+      <output>
+      </output>
     </remotesteps>
     <GUI>
-      <xloc>612</xloc>
-      <yloc>105</yloc>
+      <xloc>688</xloc>
+      <yloc>80</yloc>
       <draw>Y</draw>
     </GUI>
   </step>
-
+  <step>
+    <name>Demo table crime stats output [2]</name>
+    <type>TableOutput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>Sampledata</connection>
+    <schema/>
+    <table>${testTransParam2}</table>
+    <commit>1000</commit>
+    <truncate>N</truncate>
+    <ignore_errors>N</ignore_errors>
+    <use_batch>Y</use_batch>
+    <specify_fields>Y</specify_fields>
+    <partitioning_enabled>N</partitioning_enabled>
+    <partitioning_field/>
+    <partitioning_daily>N</partitioning_daily>
+    <partitioning_monthly>Y</partitioning_monthly>
+    <tablename_in_field>N</tablename_in_field>
+    <tablename_field/>
+    <tablename_in_table>Y</tablename_in_table>
+    <return_keys>N</return_keys>
+    <return_field/>
+    <fields>
+      <field>
+        <column_name>cdatetime</column_name>
+        <stream_name>cdatetime</stream_name>
+      </field>
+      <field>
+        <column_name>addr</column_name>
+        <stream_name>addr</stream_name>
+      </field>
+      <field>
+        <column_name>district</column_name>
+        <stream_name>district</stream_name>
+      </field>
+      <field>
+        <column_name>beat</column_name>
+        <stream_name>beat</stream_name>
+      </field>
+      <field>
+        <column_name>crimedescr</column_name>
+        <stream_name>crimedescr</stream_name>
+      </field>
+      <field>
+        <column_name>ucr_ncic_code</column_name>
+        <stream_name>ucr_ncic_code</stream_name>
+      </field>
+      <field>
+        <column_name>lat</column_name>
+        <stream_name>lat</stream_name>
+      </field>
+      <field>
+        <column_name>longitude</column_name>
+        <stream_name>longitude</stream_name>
+      </field>
+    </fields>
+    <cluster_schema/>
+    <remotesteps>
+      <input>
+      </input>
+      <output>
+      </output>
+    </remotesteps>
+    <GUI>
+      <xloc>688</xloc>
+      <yloc>208</yloc>
+      <draw>Y</draw>
+    </GUI>
+  </step>
   <step>
     <name>Sacramento crime stats 2006 file</name>
-    <type>OldTextFileInput</type>
+    <type>TextFileInput</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>
@@ -597,7 +680,7 @@
     <accept_field/>
     <accept_stepname/>
     <separator>,</separator>
-    <enclosure>&#x22;</enclosure>
+    <enclosure>"</enclosure>
     <enclosure_breaks>N</enclosure_breaks>
     <escapechar/>
     <header>Y</header>
@@ -617,9 +700,10 @@
     <rownum_field/>
     <format>Unix</format>
     <encoding/>
+    <length>Characters</length>
     <add_to_result_filenames>Y</add_to_result_filenames>
     <file>
-      <name>&#x24;&#x7b;Internal.Transformation.Filename.Directory&#x7d;&#x2f;SacramentocrimeJanuary2006.csv</name>
+      <name>${Internal.Transformation.Filename.Directory}/SacramentocrimeJanuary2006.csv</name>
       <filemask/>
       <exclude_filemask/>
       <file_required>N</file_required>
@@ -632,15 +716,15 @@
     <fields>
       <field>
         <name>cdatetime</name>
-        <type>Date</type>
-        <format>yyyy&#x2f;MM&#x2f;dd</format>
-        <currency>&#x24;</currency>
+        <type>String</type>
+        <format/>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
         <ifnull/>
         <position>-1</position>
-        <length>-1</length>
+        <length>11</length>
         <precision>-1</precision>
         <trim_type>none</trim_type>
         <repeat>N</repeat>
@@ -649,13 +733,13 @@
         <name>address</name>
         <type>String</type>
         <format/>
-        <currency>&#x24;</currency>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
         <ifnull/>
         <position>-1</position>
-        <length>40</length>
+        <length>34</length>
         <precision>-1</precision>
         <trim_type>none</trim_type>
         <repeat>N</repeat>
@@ -663,8 +747,8 @@
       <field>
         <name>district</name>
         <type>Integer</type>
-        <format>&#x23;</format>
-        <currency>&#x24;</currency>
+        <format>#</format>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
@@ -679,7 +763,7 @@
         <name>beat</name>
         <type>String</type>
         <format/>
-        <currency>&#x24;</currency>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
@@ -693,8 +777,8 @@
       <field>
         <name>grid</name>
         <type>Integer</type>
-        <format>&#x23;</format>
-        <currency>&#x24;</currency>
+        <format>#</format>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
@@ -709,7 +793,7 @@
         <name>crimedescr</name>
         <type>String</type>
         <format/>
-        <currency>&#x24;</currency>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
@@ -723,8 +807,8 @@
       <field>
         <name>ucr_ncic_code</name>
         <type>Integer</type>
-        <format>&#x23;</format>
-        <currency>&#x24;</currency>
+        <format>#</format>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
@@ -738,14 +822,14 @@
       <field>
         <name>latitude</name>
         <type>Number</type>
-        <format>&#x23;.&#x23;</format>
-        <currency>&#x24;</currency>
+        <format>#.#</format>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
         <ifnull/>
         <position>-1</position>
-        <length>15</length>
+        <length>11</length>
         <precision>8</precision>
         <trim_type>none</trim_type>
         <repeat>N</repeat>
@@ -753,14 +837,14 @@
       <field>
         <name>longitude</name>
         <type>Number</type>
-        <format>&#x23;.&#x23;</format>
-        <currency>&#x24;</currency>
+        <format>#.#</format>
+        <currency>$</currency>
         <decimal>.</decimal>
         <group>,</group>
         <nullif>-</nullif>
         <ifnull/>
         <position>-1</position>
-        <length>15</length>
+        <length>12</length>
         <precision>7</precision>
         <trim_type>none</trim_type>
         <repeat>N</repeat>
@@ -793,21 +877,22 @@
     <sizeFieldName/>
     <cluster_schema/>
     <remotesteps>
-      <input></input>
-      <output></output>
+      <input>
+      </input>
+      <output>
+      </output>
     </remotesteps>
     <GUI>
-      <xloc>231</xloc>
-      <yloc>105</yloc>
+      <xloc>208</xloc>
+      <yloc>144</yloc>
       <draw>Y</draw>
     </GUI>
   </step>
-
   <step>
     <name>Select values</name>
     <type>SelectValues</type>
     <description/>
-    <distribute>Y</distribute>
+    <distribute>N</distribute>
     <custom_distribution/>
     <copies>1</copies>
     <partitioning>
@@ -817,51 +902,28 @@
     <fields>
       <field>
         <name>cdatetime</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>address</name>
         <rename>addr</rename>
-        <length>50</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>district</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>beat</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>crimedescr</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>ucr_ncic_code</name>
-        <rename/>
-        <length>-2</length>
-        <precision>0</precision>
       </field>
       <field>
         <name>latitude</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <field>
         <name>longitude</name>
-        <rename/>
-        <length>-2</length>
-        <precision>-2</precision>
       </field>
       <select_unspecified>N</select_unspecified>
       <meta>
@@ -895,22 +957,23 @@
         <encoding/>
         <decimal_symbol>,</decimal_symbol>
         <grouping_symbol/>
-        <currency_symbol>&#x24;</currency_symbol>
+        <currency_symbol>$</currency_symbol>
         <storage_type/>
       </meta>
     </fields>
     <cluster_schema/>
     <remotesteps>
-      <input></input>
-      <output></output>
+      <input>
+      </input>
+      <output>
+      </output>
     </remotesteps>
     <GUI>
-      <xloc>418</xloc>
-      <yloc>105</yloc>
+      <xloc>416</xloc>
+      <yloc>144</yloc>
       <draw>Y</draw>
     </GUI>
   </step>
-
   <step_error_handling>
   </step_error_handling>
   <slave-step-copy-partition-distribution>
@@ -920,6 +983,22 @@
     <group>
       <name>DataService</name>
     </group>
+    <group>
+      <name>METASTORE.NamedClusters</name>
+      <attribute>
+        <key>NamedCluster</key>
+        <value>{"namespace":"NamedClusters","id":"NamedCluster","name":"NamedCluster","description":"A NamedCluster","metaStoreName":null}</value>
+      </attribute>
+    </group>
+    <group>
+      <name>explorerState</name>
+    </group>
+    <group>
+      <name>{"_":"Embedded MetaStore Elements","namespace":"NamedClusters","type":"NamedCluster"}</name>
+      <attribute>
+        <key>hdp26</key>
+        <value>{"children":[{"children":[],"id":"hdfsPassword","value":"cGFzc3dvcmQ="},{"children":[],"id":"oozieUrl","value":"http://svqxbdcn6hdp26n2.pentahoqa.com:11000"},{"children":[],"id":"mapr","value":"N"},{"children":[],"id":"useGateway","value":"N"},{"children":[],"id":"lastModifiedDate","value":"1531312119656"},{"children":[],"id":"jobTrackerHost","value":"svqxbdcn6hdp26n2.pentahoqa.com"},{"children":[],"id":"zooKeeperHost","value":"svqxbdcn6hdp26n1.pentahoqa.com"},{"children":[],"id":"shimIdentifier","value":null},{"children":[],"id":"gatewayUrl","value":null},{"children":[],"id":"jobTrackerPort","value":"8050"},{"children":[],"id":"zooKeeperPort","value":"2181"},{"children":[],"id":"name","value":"hdp26"},{"children":[],"id":"hdfsPort","value":"8020"},{"children":[],"id":"hdfsUsername","value":"devuser"},{"children":[],"id":"gatewayPassword","value":null},{"children":[],"id":"kafkaBootstrapServers","value":null},{"children":[],"id":"storageScheme","value":"hdfs"},{"children":[],"id":"hdfsHost","value":"svqxbdcn6hdp26n3.pentahoqa.com"},{"children":[],"id":"gatewayUsername","value":null}],"id":"hdp26","value":null,"name":"hdp26","owner":null,"ownerPermissionsList":[]}</value>
+      </attribute>
+    </group>
   </attributes>
-
 </transformation>

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/streamlookup/StreamLookupStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/streamlookup/StreamLookupStepAnalyzer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -197,5 +197,15 @@ public class StreamLookupStepAnalyzer extends StepAnalyzer<StreamLookupMeta> {
     this.parentStepMeta = parentStepMeta;
   }
   // ******** End - Used to aid in unit testing **********
+
+  /**
+   * Stream Lookup is a special sten, only take into account the first input step
+   * @param rowMeta
+   * @param rmi
+   */
+  protected void populateInputFieldsRowMeta( final Map<String, RowMetaInterface> rowMeta, final RowMetaInterface rmi ) {
+    rowMeta.put( prevStepNames[ 0 ], rmi );
+  }
+
 
 }

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputStepAnalyzer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -112,4 +112,11 @@ public class TableInputStepAnalyzer extends ConnectionExternalResourceStepAnalyz
   public void setBaseStepMeta( TableInputMeta meta ) {
     baseStepMeta = meta;
   }
+
+  @Override
+  protected void customAnalyze( TableInputMeta meta, IMetaverseNode rootNode ) throws MetaverseAnalyzerException {
+    super.customAnalyze( meta, rootNode );
+    rootNode.setProperty( DictionaryConst.PROPERTY_QUERY, parentTransMeta.environmentSubstitute( meta.getSQL() ) );
+  }
+
 }

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzer.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,7 +69,7 @@ public class TableOutputStepAnalyzer extends ConnectionExternalResourceStepAnaly
     BaseDatabaseResourceInfo resourceInfo = (BaseDatabaseResourceInfo) resource;
 
     Object obj = resourceInfo.getAttributes().get( DictionaryConst.PROPERTY_TABLE );
-    String tableName = obj == null ? null : obj.toString();
+    String tableName = obj == null ? null : parentTransMeta.environmentSubstitute( obj.toString() );
     obj = resourceInfo.getAttributes().get( DictionaryConst.PROPERTY_SCHEMA );
     String schema = obj == null ? null : obj.toString();
 

--- a/core/src/main/java/org/pentaho/metaverse/graph/BaseGraphWriter.java
+++ b/core/src/main/java/org/pentaho/metaverse/graph/BaseGraphWriter.java
@@ -1,0 +1,294 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.graph;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.Vertex;
+import org.apache.commons.collections.IteratorUtils;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IGraphWriter;
+import org.pentaho.metaverse.api.model.BaseMetaverseBuilder;
+import org.pentaho.metaverse.impl.MetaverseConfig;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A base implementation of the {@link IGraphWriter}.
+ */
+public abstract class BaseGraphWriter implements IGraphWriter {
+
+  public static void adjustGraph( final Graph graph ) {
+    if ( MetaverseConfig.deduplicateTransformationFields() ) {
+      deduplicateTransFields( graph );
+    }
+
+    if ( MetaverseConfig.adjustExternalResourceFields() ) {
+      // first add the missing links from each external resources to their fields
+      addExternalResourceContainsFieldsLinks( graph );
+
+      // if a single step reads more than one external resource, we will now likely have duplicate fields "contain"ed by
+      // each resource, which need to be de-duplicated
+      deduplicateExternalResourceFields( graph );
+    }
+  }
+
+  @Override
+  public final void outputGraph( Graph graph, OutputStream graphMLOutputStream ) throws IOException {
+
+    adjustGraph( graph );
+    outputGraphImpl( graph, graphMLOutputStream );
+  }
+
+  protected abstract void outputGraphImpl( final Graph graph, final OutputStream outputStream ) throws IOException;
+
+  private static Set<Vertex> getVerticesByCategoryAndName( final Graph graph, final String category,
+                                                           final String name ) {
+    final Iterator<Vertex> allVertices = graph.getVertices().iterator();
+
+    final Set<Vertex> documentElementVertices = new HashSet();
+    while ( allVertices.hasNext() ) {
+      final Vertex vertex = allVertices.next();
+      if ( ( category == null || category.equals( vertex.getProperty( DictionaryConst.PROPERTY_CATEGORY ) ) )
+        && ( name == null || name.equals( vertex.getProperty( DictionaryConst.PROPERTY_NAME ) ) ) ) {
+        documentElementVertices.add( vertex );
+      }
+    }
+    return documentElementVertices;
+  }
+
+  private static Set<Vertex> getVerticesByCategory( final Graph graph, final String category ) {
+    return getVerticesByCategoryAndName( graph, category, null );
+  }
+
+  /**
+   * Returns all vertices categorized as "documentelement", which corresponds to all Step and Job Entry vertices.
+   *
+   * @param graph the {@link Graph}
+   * @return a {@link Set} of vertices corresponding to Steps and Job Enties.
+   */
+  private static Set<Vertex> getDocumentElementVertices( final Graph graph ) {
+    return getVerticesByCategory( graph, DictionaryConst.CATEGORY_DOCUMENT_ELEMENT );
+  }
+
+  private static void deduplicateTransFields( final Graph graph ) {
+    // get all Step and Job Entry nodes
+    final Iterator<Vertex> documentElementVertices = getDocumentElementVertices( graph ).iterator();
+
+    while ( documentElementVertices.hasNext() ) {
+      final Vertex documentElementVertex = documentElementVertices.next();
+      // merge fields at the end of the "outputs" edges
+      mergeFields( graph, documentElementVertex, Direction.OUT, DictionaryConst.LINK_OUTPUTS, true );
+    }
+  }
+
+  private static void mergeFields( final Graph graph, final Vertex documentElementVertex, final Direction direction,
+                                   final String linkLabel, boolean isTransformationField ) {
+    // get all edges corresponding to the requested direction and with the requested label
+    final List<Edge> links = IteratorUtils.toList(
+      documentElementVertex.getEdges( direction, linkLabel ).iterator() );
+    // traverse the links and see if there are any that point to fields with the same names, if so, they need to be
+    // merged
+    final Map<String, Set<Vertex>> fieldMap = new HashMap();
+    for ( final Edge link : links ) {
+      // get the vertex at the "other" end of this linnk ("this" end being the vertex itself)
+      final Vertex vertex = link.getVertex( direction == Direction.IN ? Direction.OUT : Direction.IN );
+      final String category = vertex.getProperty( DictionaryConst.PROPERTY_CATEGORY );
+      final String type = vertex.getProperty( DictionaryConst.PROPERTY_TYPE );
+      // verify that the vertex is a field of the desired type
+      if ( DictionaryConst.CATEGORY_FIELD.equals( category )
+        && isTransformationField == DictionaryConst.NODE_TYPE_TRANS_FIELD.equals( type ) ) {
+        final String fieldName = vertex.getProperty( DictionaryConst.PROPERTY_NAME );
+
+        Set<Vertex> fieldsWithSameName = fieldMap.get( fieldName );
+        if ( fieldsWithSameName == null ) {
+          fieldsWithSameName = new HashSet();
+          fieldMap.put( fieldName, fieldsWithSameName );
+        }
+        fieldsWithSameName.add( vertex );
+      }
+    }
+
+    // traverse the map pf fields - for any field name, if more than one has been found, merge them into one
+    final List<Map.Entry<String, Set<Vertex>>> fields = IteratorUtils.toList( fieldMap.entrySet().iterator() );
+    for ( final Map.Entry<String, Set<Vertex>> fieldEntry : fields ) {
+      final List<Vertex> fieldVertices = new ArrayList( fieldEntry.getValue() );
+      if ( fieldVertices.size() > 1 ) {
+        // get the first vertex - we will keep this one and re-point links connected to all the rest back to this
+        // original one, and then remove the remaining ones
+        final Vertex fieldVertexToKeep = fieldVertices.get( 0 );
+        for ( int i = 1; i < fieldVertices.size(); i++ ) {
+          final Vertex fieldVertexToMerge = fieldVertices.get( i );
+          rewireEdges( graph, fieldVertexToKeep, fieldVertexToMerge, Direction.IN );
+          rewireEdges( graph, fieldVertexToKeep, fieldVertexToMerge, Direction.OUT );
+          // we can now safely remove 'fieldVertexToMerge'
+          fieldVertexToMerge.remove();
+        }
+      }
+    }
+  }
+
+  private static void rewireEdges( final Graph graph, final Vertex vertexToKeep, final Vertex vertexToMerge,
+                                   final Direction direction ) {
+    final Iterator<Edge> links = vertexToMerge.getEdges( direction ).iterator();
+    while ( links.hasNext() ) {
+      // remove this edge and recreate one that points to 'fieldVertexToKeep' instead of 'fieldVertexToMerge',
+      // where it pointed originally
+      final Edge originalLink = links.next();
+      final String newLinkId = direction == Direction.OUT
+        ? BaseMetaverseBuilder.getEdgeId(
+        vertexToKeep, originalLink.getLabel(), originalLink.getVertex( Direction.IN ) )
+        : BaseMetaverseBuilder.getEdgeId(
+        originalLink.getVertex( Direction.OUT ), originalLink.getLabel(), vertexToKeep );
+      if ( graph.getEdge( newLinkId ) == null ) {
+        if ( direction == Direction.OUT ) {
+          graph.addEdge( newLinkId, vertexToKeep, originalLink.getVertex( Direction.IN ), originalLink.getLabel() )
+            .setProperty( "text", originalLink.getLabel() );
+        } else {
+          graph.addEdge( newLinkId, originalLink.getVertex( Direction.OUT ), vertexToKeep,
+            originalLink.getLabel() ).setProperty( "text", originalLink.getLabel() );
+        }
+      }
+      // remove the original link
+      originalLink.remove();
+    }
+  }
+
+  private static Set<Vertex> getCollectionVertices( final Graph graph ) {
+    return getVerticesByCategory( graph, DictionaryConst.CATEGORY_FIELD_COLLECTION );
+  }
+
+  private static Set<Vertex> getSQLVertices( final Graph graph ) {
+    return getVerticesByCategoryAndName( graph, DictionaryConst.CATEGORY_OTHER, DictionaryConst.NODE_NAME_SQL );
+  }
+
+  private static Set<Vertex> getExternalResourceVertices( final Graph graph ) {
+    final Set<Vertex> externalResourceVertexSet = getCollectionVertices( graph );
+    externalResourceVertexSet.addAll( getSQLVertices( graph ) );
+    return externalResourceVertexSet;
+  }
+
+  private static List<Vertex> getLinkedVertices( final Vertex originVertex, final Direction edgeDirection,
+                                                 final String edgeLabel,
+                                                 final String linkedVertexCategory, final boolean equalToCategory,
+                                                 final String linkedVertexType, final boolean equalToType ) {
+
+    final List<Vertex> linkedVertices = new ArrayList();
+    final Iterator<Edge> links = originVertex.getEdges( edgeDirection, edgeLabel ).iterator();
+    while ( links.hasNext() ) {
+      final Edge link = links.next();
+      // get the vertex at the opposite end of the edge
+      final Vertex vertex = link.getVertex( edgeDirection == Direction.IN ? Direction.OUT : Direction.IN );
+      final String category = vertex.getProperty( DictionaryConst.PROPERTY_CATEGORY );
+      final String type = vertex.getProperty( DictionaryConst.PROPERTY_TYPE );
+      if ( ( linkedVertexCategory == null
+        || ( category != null && equalToCategory == category.equals( linkedVertexCategory ) ) )
+        && ( linkedVertexType == null
+        || ( type != null && equalToType == type.equals( linkedVertexType ) ) ) ) {
+        linkedVertices.add( vertex );
+      }
+    }
+    return linkedVertices;
+  }
+
+  private static List<Vertex> getStepInputExternalResourceFields( final Vertex stepVertex ) {
+    return getLinkedVertices( stepVertex, Direction.IN,
+      DictionaryConst.LINK_INPUTS, DictionaryConst.CATEGORY_FIELD, true,
+      DictionaryConst.NODE_TYPE_TRANS_FIELD, false );
+  }
+
+  private static List<Vertex> getStepOutputExternalResourceFields( final Vertex stepVertex ) {
+    return getLinkedVertices( stepVertex, Direction.OUT,
+      DictionaryConst.LINK_OUTPUTS, DictionaryConst.CATEGORY_FIELD, true,
+      DictionaryConst.NODE_TYPE_TRANS_FIELD, false );
+  }
+
+  private static List<Vertex> getStepsReadingExternalResource( final Vertex extenralResourceVertex ) {
+    return getLinkedVertices( extenralResourceVertex, Direction.OUT,
+      DictionaryConst.LINK_READBY, DictionaryConst.CATEGORY_DOCUMENT_ELEMENT, true, null, false );
+  }
+
+  private static List<Vertex> getStepsWritingToExternalResource( final Vertex extenralResourceVertex ) {
+    return getLinkedVertices( extenralResourceVertex, Direction.IN,
+      DictionaryConst.LINK_WRITESTO, DictionaryConst.CATEGORY_DOCUMENT_ELEMENT, true, null, false );
+  }
+
+  // add "contains" edges only to fields and columns which input into the step
+  private static void addExternalResourceContainsFieldsLinks( final Graph graph ) {
+    // get all external resources (files, SQL queries, database tables etc...)
+    final Iterator<Vertex> externalResourceVertices = getExternalResourceVertices( graph ).iterator();
+
+    while ( externalResourceVertices.hasNext() ) {
+      final Vertex externalResourceVertex = externalResourceVertices.next();
+      // for each external resource vertex, get all steps that read it
+      List<Vertex> stepVertices = getStepsReadingExternalResource( externalResourceVertex );
+      for ( final Vertex stepVertex : stepVertices ) {
+
+        // for each step, get all non-transformation fields linked through the IN "inputs" edges
+        final List<Vertex> fieldVertices = getStepInputExternalResourceFields( stepVertex );
+        addContainsLinks( graph, externalResourceVertex, fieldVertices );
+      }
+      stepVertices = getStepsWritingToExternalResource( externalResourceVertex );
+      for ( final Vertex stepVertex : stepVertices ) {
+        // for each step, get all non-transformation fields linked through the OUT "outputs" edges
+        final List<Vertex> fieldVertices = getStepOutputExternalResourceFields( stepVertex );
+        addContainsLinks( graph, externalResourceVertex, fieldVertices );
+      }
+    }
+  }
+
+  private static void addContainsLinks( final Graph graph, final Vertex externalResourceVertex,
+                                        final List<Vertex> fieldVertices ) {
+    for ( final Vertex fieldVertex : fieldVertices ) {
+      final String newLinkId = BaseMetaverseBuilder.getEdgeId(
+        externalResourceVertex, DictionaryConst.LINK_CONTAINS, fieldVertex );
+      if ( graph.getEdge( newLinkId ) == null ) {
+        // add a "contains" link from the external resource to the field, if one doesn't already exist
+        graph.addEdge( newLinkId, externalResourceVertex, fieldVertex, DictionaryConst.LINK_CONTAINS )
+          .setProperty( "text", DictionaryConst.LINK_CONTAINS );
+      }
+    }
+  }
+
+  private static void deduplicateExternalResourceFields( final Graph graph ) {
+    // get all external resources (files, SQL queries, database tables etc...)
+    final Iterator<Vertex> externalResourceVertices = getExternalResourceVertices( graph ).iterator();
+
+    // traverse the links and see if there are any that point to fields with the same names, if so, they need to be
+    // merged
+    while ( externalResourceVertices.hasNext() ) {
+      final Vertex vertex = externalResourceVertices.next();
+      // merge non-transformation fields at the end of the "outputs" edges
+      mergeFields( graph, vertex, Direction.OUT, DictionaryConst.LINK_CONTAINS, false );
+    }
+  }
+}

--- a/core/src/main/java/org/pentaho/metaverse/graph/GraphCsvWriter.java
+++ b/core/src/main/java/org/pentaho/metaverse/graph/GraphCsvWriter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,6 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 import org.pentaho.dictionary.DictionaryConst;
-import org.pentaho.metaverse.api.IGraphWriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,12 +36,12 @@ import java.util.Iterator;
  * The GraphMLWriter class contains methods for writing a metaverse graph model in GraphML format
  * 
  */
-public class GraphCsvWriter implements IGraphWriter {
+public class GraphCsvWriter extends BaseGraphWriter {
 
   private static final String CSV_ENCLOSURE = "\"";
 
   @Override
-  public void outputGraph( Graph graph, OutputStream out ) throws IOException {
+  public void outputGraphImpl( Graph graph, OutputStream out ) throws IOException {
 
     Iterable<Edge> iterable = graph.getEdges();
     Iterator<Edge> it = iterable.iterator();

--- a/core/src/main/java/org/pentaho/metaverse/graph/GraphMLWriter.java
+++ b/core/src/main/java/org/pentaho/metaverse/graph/GraphMLWriter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,25 +23,21 @@
 package org.pentaho.metaverse.graph;
 
 import com.tinkerpop.blueprints.Graph;
-import org.pentaho.metaverse.api.IGraphWriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
 /**
  * The GraphMLWriter class contains methods for writing a metaverse graph model in GraphML format
- * 
  */
-public class GraphMLWriter implements IGraphWriter {
+public class GraphMLWriter extends BaseGraphWriter {
 
   @Override
-  public void outputGraph( Graph graph, OutputStream graphMLOutputStream ) throws IOException {
+  public void outputGraphImpl( Graph graph, OutputStream graphMLOutputStream ) throws IOException {
     com.tinkerpop.blueprints.util.io.graphml.GraphMLWriter writer =
-        new com.tinkerpop.blueprints.util.io.graphml.GraphMLWriter( graph );
+      new com.tinkerpop.blueprints.util.io.graphml.GraphMLWriter( graph );
 
     writer.setNormalize( true );
     writer.outputGraph( graphMLOutputStream );
-    //    com.tinkerpop.blueprints.util.io.graphml.GraphMLWriter.outputGraph( graph, graphMLOutputStream );
   }
-
 }

--- a/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
@@ -23,6 +23,7 @@
 package org.pentaho.metaverse.impl;
 
 import org.pentaho.metaverse.api.IMetaverseConfig;
+import org.pentaho.metaverse.util.MetaverseBeanUtil;
 
 /**
  * A single point of access for all metaverse osgi configuration properties.
@@ -32,10 +33,17 @@ public class MetaverseConfig implements IMetaverseConfig {
   private String executionRuntime = "off";
   private String extecutionOutputFolder = "./pentaho-lineage-output";
   private String executionGenerationStrategy = "latest";
-  private boolean resolveExternalResources = false;
+  private boolean resolveExternalResources = true;
+  private boolean deduplicateTransformationFields = true;
+  private boolean adjustExternalResourceFields = true;
+
   // Used for testing ONLY, to verify that any listeners waiting for lineage to be written aren't invoked until
   // graphml has been written
   private int lineageDelay = 0;
+
+  public static MetaverseConfig getInstance() {
+    return (MetaverseConfig) MetaverseBeanUtil.getInstance().get( "metaverseConfig" );
+  }
 
   public void setExecutionRuntime( final String executionRuntime ) {
     this.executionRuntime = executionRuntime;
@@ -67,6 +75,32 @@ public class MetaverseConfig implements IMetaverseConfig {
 
   public boolean getResolveExternalResources() {
     return this.resolveExternalResources;
+  }
+
+  public void setDeduplicateTransformationFields( final boolean deduplicateTransformationFields ) {
+    this.deduplicateTransformationFields = deduplicateTransformationFields;
+  }
+
+  public boolean getDeduplicateTransformationFields() {
+    return this.deduplicateTransformationFields;
+  }
+
+  public static boolean deduplicateTransformationFields() {
+    final MetaverseConfig config = getInstance();
+    return config != null && config.getDeduplicateTransformationFields();
+  }
+
+  public void setAdjustExternalResourceFields( final boolean adjustExternalResourceFields ) {
+    this.adjustExternalResourceFields = adjustExternalResourceFields;
+  }
+
+  public boolean getAdjustExternalResourceFields() {
+    return this.adjustExternalResourceFields;
+  }
+
+  public static boolean adjustExternalResourceFields() {
+    final MetaverseConfig config = getInstance();
+    return config != null && config.getAdjustExternalResourceFields();
   }
 
   public void setLineageDelay( final int lineageDelay ) {

--- a/core/src/main/java/org/pentaho/metaverse/impl/VfsLineageWriter.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/VfsLineageWriter.java
@@ -91,16 +91,16 @@ public class VfsLineageWriter implements ILineageWriter {
     if ( holder != null ) {
       IMetaverseBuilder builder = holder.getMetaverseBuilder();
       if ( builder != null ) {
+        // no-op by default, can be used to introduce an artificial delay in the graphml file, for testing purposes
+        MetaverseUtil.delay();
         try ( OutputStream fos = getGraphOutputStream( holder ) ) {
           if ( fos != null ) {
-            // no-op by default, can be used to introduce an artificial delay in the graphml file, for testing purposes
-            MetaverseUtil.delay();
             graphWriter.outputGraph( builder.getGraph(), fos );
-            MetaverseUtil.delay();
           } else {
             log.debug( Messages.getString( "DEBUG.noGraphOutputStream" ) );
           }
         }
+        MetaverseUtil.delay();
       }
     }
   }

--- a/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
@@ -231,7 +231,7 @@ public class MetaverseUtil {
    * output wait sufficiently long enough for the file to be finished writing before attempting to process it.
    */
   public static void delay() {
-    final MetaverseConfig metaverseConfig = (MetaverseConfig) MetaverseBeanUtil.getInstance().get( "metaverseConfig" );
+    final MetaverseConfig metaverseConfig = MetaverseConfig.getInstance();
     if ( metaverseConfig != null && metaverseConfig.getLineageDelay() > 0 ) {
       try {
         Thread.sleep( metaverseConfig.getLineageDelay() * 1000 );

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,7 +13,9 @@
       <cm:property name="lineage.execution.runtime" value="off"/>
       <cm:property name="lineage.execution.output.folder" value="./pentaho-lineage-output"/>
       <cm:property name="lineage.execution.generation.strategy" value="latest"/>
-      <cm:property name="lineage.resolve.external.resources" value="false"/>
+      <cm:property name="lineage.resolve.external.resources" value="true"/>
+      <cm:property name="lineage.deduplicate.transformation.fields" value="true"/>
+      <cm:property name="lineage.adjust.external.resource.fields" value="true"/>
       <!-- Used for testing ONLY - write delay in seconds -->
       <cm:property name="lineage.delay" value="0"/>
     </cm:default-properties>
@@ -35,6 +37,8 @@
     <property name="executionOutputFolder" value="${lineage.execution.output.folder}"/>
     <property name="executionGenerationStrategy" value="${lineage.execution.generation.strategy}"/>
     <property name="resolveExternalResources" value="${lineage.resolve.external.resources}"/>
+    <property name="deduplicateTransformationFields" value="${lineage.deduplicate.transformation.fields}"/>
+    <property name="adjustExternalResourceFields" value="${lineage.adjust.external.resource.fields}"/>
     <!-- Used for testing ONLY - write delay in seconds -->
     <property name="lineageDelay" value="${lineage.delay}"/>
   </bean>

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -80,6 +80,8 @@ public class TableOutputStepAnalyzerTest {
 
   IComponentDescriptor descriptor;
 
+  private static final String TABLE_NAME = "myTableName";
+
   @Before
   public void setUp() throws Exception {
     IMetaverseObjectFactory factory = MetaverseTestUtils.getMetaverseObjectFactory();
@@ -100,6 +102,8 @@ public class TableOutputStepAnalyzerTest {
     when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
     when( parentStepMeta.getName() ).thenReturn( "test" );
     when( parentStepMeta.getStepID() ).thenReturn( "TableOutputStep" );
+
+    when( parentTransMeta.environmentSubstitute( TABLE_NAME ) ).thenReturn( TABLE_NAME );
   }
 
   @Test
@@ -129,10 +133,9 @@ public class TableOutputStepAnalyzerTest {
     IMetaverseNode connNode = mock( IMetaverseNode.class );
     when( connectionAnalyzer.analyze( any( IComponentDescriptor.class ), anyObject() ) ).thenReturn( connNode );
 
-
     BaseDatabaseResourceInfo resourceInfo = mock( BaseDatabaseResourceInfo.class );
     Map<Object, Object> attributes = new HashMap<>();
-    attributes.put( DictionaryConst.PROPERTY_TABLE, "tableName" );
+    attributes.put( DictionaryConst.PROPERTY_TABLE, TABLE_NAME );
     attributes.put( DictionaryConst.PROPERTY_SCHEMA, "schemaName" );
     when( resourceInfo.getAttributes() ).thenReturn( attributes );
 
@@ -141,8 +144,8 @@ public class TableOutputStepAnalyzerTest {
     when( connectionNode.getLogicalId() ).thenReturn( "CONNECTION_ID" );
 
     IMetaverseNode resourceNode = analyzer.createTableNode( resourceInfo );
-    assertEquals( "tableName", resourceNode.getProperty( DictionaryConst.PROPERTY_TABLE ) );
-    assertEquals( "tableName", resourceNode.getName() );
+    assertEquals( TABLE_NAME, resourceNode.getProperty( DictionaryConst.PROPERTY_TABLE ) );
+    assertEquals( TABLE_NAME, resourceNode.getName() );
     assertEquals( "schemaName", resourceNode.getProperty( DictionaryConst.PROPERTY_SCHEMA ) );
     assertEquals( "CONNECTION_ID", resourceNode.getProperty( DictionaryConst.PROPERTY_NAMESPACE ) );
   }
@@ -155,10 +158,9 @@ public class TableOutputStepAnalyzerTest {
     IMetaverseNode connNode = mock( IMetaverseNode.class );
     when( connectionAnalyzer.analyze( any( IComponentDescriptor.class ), anyObject() ) ).thenReturn( connNode );
 
-
     BaseDatabaseResourceInfo resourceInfo = mock( BaseDatabaseResourceInfo.class );
     Map<Object, Object> attributes = new HashMap<>();
-    attributes.put( DictionaryConst.PROPERTY_TABLE, "tableName" );
+    attributes.put( DictionaryConst.PROPERTY_TABLE, TABLE_NAME );
     when( resourceInfo.getAttributes() ).thenReturn( attributes );
 
     IMetaverseNode connectionNode = mock( IMetaverseNode.class );
@@ -166,8 +168,8 @@ public class TableOutputStepAnalyzerTest {
     when( connectionNode.getLogicalId() ).thenReturn( "CONNECTION_ID" );
 
     IMetaverseNode resourceNode = analyzer.createTableNode( resourceInfo );
-    assertEquals( "tableName", resourceNode.getProperty( DictionaryConst.PROPERTY_TABLE ) );
-    assertEquals( "tableName", resourceNode.getName() );
+    assertEquals( TABLE_NAME, resourceNode.getProperty( DictionaryConst.PROPERTY_TABLE ) );
+    assertEquals( TABLE_NAME, resourceNode.getName() );
     assertNull( resourceNode.getProperty( DictionaryConst.PROPERTY_SCHEMA ) );
     assertEquals( "CONNECTION_ID", resourceNode.getProperty( DictionaryConst.PROPERTY_NAMESPACE ) );
   }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
   <properties>
     <dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>
     <dependency.pentaho.pentaho-platform-repository.version>${project.version}</dependency.pentaho.pentaho-platform-repository.version>
-    <dependency.com.fasterxml.jackson.core.version>2.9.4</dependency.com.fasterxml.jackson.core.version>
     <dependency.org.slf4j.slf4j-log4j12.version>1.7.7</dependency.org.slf4j.slf4j-log4j12.version>
     <dependency.junit.junit.version>4.11</dependency.junit.junit.version>
     <dependency.com.tinkerpop.blueprints.version>2.6.0</dependency.com.tinkerpop.blueprints.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,7 +21,6 @@
     <enunciate.version>1.27</enunciate.version>
     <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
     <maven-pmd-plugin.version>3.2</maven-pmd-plugin.version>
-    <fasterxml.jackson.version>2.9.4</fasterxml.jackson.version>
   </properties>
   <dependencies>
     <dependency>
@@ -39,7 +38,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${dependency.com.fasterxml.jackson.core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.enunciate</groupId>
@@ -59,12 +57,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
In order to implement field level lineage in IGC, some changes needed to be made to the graph produces by the metaverse project. These changes included adding directly "contains" links from external resources to their fields and de-duplicating fields from a step that has more than one target step.

Additional changes:
 - Fixed the table input step which lost the SQL query; igc used to grab it with roundabout logic that was removed, not the property is directly on the step node and shows in igc through a generic mechanism that displays all step properties in the header section
- made a change so that fields from all input steps (if more than one) are included and graphml and linked to the target step; this used to not be the case, only fields from the first encountered input step would be created, other input step nodes were included in the graph but without any fields; The stream lookup step is the only exception, where the first step should be read, as the lookup table step is handled in a different / special way