### PR TITLE
[BACKLOG-26731] Additional changes to allow running sub-transformations that read files from field

### DIFF
--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
@@ -1,0 +1,210 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.api.analyzer.kettle;
+
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A cache of resources encountered when a transformation is run that can be used to access these run-time resources at
+ * a later time, when data lineage analysis occurs.
+ */
+public class ExternalResourceCache {
+
+  private static final Logger log = LoggerFactory.getLogger( ExternalResourceCache.class );
+
+  protected volatile Map<String, TransValues> transMap = new ConcurrentHashMap();
+
+  protected volatile Map<String, ExternalResourceValues> resourceMap = new ConcurrentHashMap();
+
+  private static ExternalResourceCache INSTANCE;
+
+  public static ExternalResourceCache getInstance() {
+    if ( INSTANCE == null ) {
+      synchronized ( ExternalResourceCache.class ) {
+        if ( INSTANCE == null ) {
+          INSTANCE = new ExternalResourceCache();
+        }
+      }
+    }
+    return INSTANCE;
+  }
+
+  private ExternalResourceCache() {
+  }
+
+  protected String getUniqueId( final StepMeta meta ) {
+
+    if ( meta == null || meta.getParentTransMeta() == null ) {
+      return null;
+    }
+    final TransMeta transMeta = meta.getParentTransMeta();
+    if ( transMeta.getRepository() == null ) {
+      return KettleAnalyzerUtil.normalizeFilePathSafely( transMeta.getFilename() ) + "::" + meta.getName();
+    } else {
+      return transMeta.getPathAndName() + "." + transMeta.getDefaultExtension()
+        + "::" + meta.getName();
+    }
+  }
+
+  public void removeCachedResources( final Trans trans ) {
+    final TransMeta transMeta = trans.getTransMeta();
+    final List<StepMeta> steps = transMeta.getSteps();
+    for ( final StepMeta step : steps ) {
+      final String uniqueMetaId = getUniqueId( step );
+
+      Resources<Trans> transformations = transMap.get( uniqueMetaId );
+      if ( transformations != null && transformations.contains( trans ) ) {
+        transformations.remove( trans );
+      }
+      // are there any other potentially running transformations that might be using this resource? If not, the
+      // resource can be removed, otherwise keep it
+      if ( transformations == null || transformations.size() == 0 ) {
+        resourceMap.remove( uniqueMetaId );
+        transMap.remove( uniqueMetaId );
+      }
+    }
+  }
+
+  public Resources<IExternalResourceInfo> get( final Trans trans, final BaseStepMeta meta ) {
+    if ( meta == null ) {
+      return null;
+    }
+    cacheTrans( trans, meta );
+    final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
+    return resourceMap.get( uniqueMetaId );
+  }
+
+  private void cacheTrans( final Trans trans, final BaseStepMeta meta ) {
+    if ( trans != null ) {
+      final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
+      TransValues transformations = transMap.get( uniqueMetaId );
+      if ( transformations == null ) {
+        transformations = new TransValues();
+        transMap.put( uniqueMetaId, transformations );
+      }
+      transformations.add( trans );
+    }
+  }
+
+  public void cache( final Trans trans, final BaseStepMeta meta, final ExternalResourceValues resources ) {
+    cacheTrans( trans, meta );
+    final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
+    resourceMap.put( uniqueMetaId, resources );
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+
+    for ( Map.Entry<String, ExternalResourceValues> entry : resourceMap.entrySet() ) {
+      sb.append( " ---- " + entry.getKey() + ": " + entry.getValue().size() + "\n" );
+      sb.append( entry.getValue().toString() );
+    }
+    for ( Map.Entry<String, TransValues> entry : transMap.entrySet() ) {
+      sb.append( " ---- " + entry.getKey() + ": " + entry.getValue().size() + "\n" );
+      sb.append( entry.getValue().toString() );
+    }
+
+    log.debug( "\n" + sb.toString() );
+    return sb.toString();
+  }
+
+  public ExternalResourceValues newExternalResourceValues() {
+    return new ExternalResourceValues();
+  }
+
+  public class ExternalResourceValues extends Resources<IExternalResourceInfo> {
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      for ( IExternalResourceInfo resource : internal ) {
+        sb.append( " ............ " ).append( resource.getClass().getSimpleName() ).append( " " ).append( resource
+          .getName() ).append( " (" ).append( resource.hashCode() ).append( ") \n" );
+      }
+      return sb.toString();
+    }
+
+  }
+
+  public class TransValues extends Resources<Trans> {
+  }
+
+  /**
+   * A wrapper class that provides controlled access to a {@link Set} of values.
+   *
+   * @param <V> the type of object stored in the internal {@link Set}.
+   */
+  public abstract class Resources<V> {
+
+    protected Set<V> internal = new ConcurrentHashSet();
+
+    public void add( final V value ) {
+      internal.add( value );
+    }
+
+    public boolean remove( final V value ) {
+      return internal.remove( value );
+    }
+
+    public int size() {
+      return internal.size();
+    }
+
+    public boolean contains( final V value ) {
+      return internal.contains( value );
+    }
+
+    /**
+     * Returns a copy of the original {@code internal} {@link Set}
+     *
+     * @return a copy of the original {@code internal} {@link Set}
+     */
+    public Set<V> getInternal() {
+      return new HashSet( this.internal );
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      for ( V value : internal ) {
+        sb.append( " ............ " ).append( value.getClass().getSimpleName() ).append( " " ).append(
+          value.hashCode() ).append( "\n" );
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
@@ -22,9 +22,7 @@
 
 package org.pentaho.metaverse.api.analyzer.kettle;
 
-import com.google.common.collect.MapMaker;
 import org.apache.commons.vfs2.FileObject;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
@@ -39,7 +37,6 @@ import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.ISubTransAwareMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
-import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputStep;
 import org.pentaho.dictionary.DictionaryConst;
@@ -64,16 +61,12 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URLConnection;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 public class KettleAnalyzerUtil {
 
   private static final Logger log = LoggerFactory.getLogger( KettleAnalyzerUtil.class );
 
-  private static Map<String, Collection<IExternalResourceInfo>> resourceMap =
-    Collections.synchronizedMap( new MapMaker().weakValues().makeMap() );
+  private static final ExternalResourceCache rowResourceCache = ExternalResourceCache.getInstance();
 
   /**
    * Utility method for normalizing file paths used in Metaverse Id generation. It will convert a valid path into a
@@ -111,39 +104,12 @@ public class KettleAnalyzerUtil {
     return filePath;
   }
 
-  public static void removeResources( final TransMeta transMeta ) {
-    final List<StepMeta> steps = transMeta.getSteps();
-    for ( final StepMeta step : steps ) {
-      KettleAnalyzerUtil.removeResources( step );
-    }
-  }
-
-  protected static Collection<IExternalResourceInfo> removeResources( final StepMeta meta ) {
-    if ( resourceMap != null ) {
-      return resourceMap.remove( getUniqueId( meta ) );
-    }
-    return null;
-  }
-
-  protected static String getUniqueId( final StepMeta meta ) {
-
-    final TransMeta transMeta = meta.getParentTransMeta();
-    if ( transMeta.getRepository() == null ) {
-      return normalizeFilePathSafely( transMeta.getFilename() ) + "::"  + meta.getName();
-    } else {
-      return meta.getParentTransMeta().getPathAndName() + "." + meta.getParentTransMeta().getDefaultExtension()
-        + "::"  + meta.getName();
-    }
-  }
-
   public static Collection<IExternalResourceInfo> getResourcesFromMeta(
     final BaseStepMeta meta, final String[] filePaths ) {
 
-    final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
-    Collection<IExternalResourceInfo> resources = resourceMap.get( uniqueMetaId );
+    ExternalResourceCache.Resources resources = rowResourceCache.get( null, meta );
     if ( resources == null ) {
-      resources = new ConcurrentHashSet();
-      resourceMap.put( uniqueMetaId, resources );
+      resources = rowResourceCache.newExternalResourceValues();
     }
 
     if ( meta != null && meta.getParentStepMeta() != null && filePaths != null && filePaths.length > 0 ) {
@@ -164,7 +130,7 @@ public class KettleAnalyzerUtil {
         }
       }
     }
-    return resources;
+    return resources.getInternal();
   }
 
   public static Collection<IExternalResourceInfo> getResourcesFromRow(
@@ -175,12 +141,11 @@ public class KettleAnalyzerUtil {
     if ( meta == null ) {
       meta = (BaseFileInputMeta) step.getStepMeta().getStepMetaInterface();
     }
-
-    final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
-    Collection<IExternalResourceInfo> resources = resourceMap.get( uniqueMetaId );
+    ExternalResourceCache.ExternalResourceValues resources =
+      (ExternalResourceCache.ExternalResourceValues) rowResourceCache.get( step.getTrans(), meta );
     if ( resources == null ) {
-      resources = new ConcurrentHashSet();
-      resourceMap.put( uniqueMetaId, resources );
+      resources = rowResourceCache.newExternalResourceValues();
+      rowResourceCache.cache( step.getTrans(), meta, resources );
     }
 
     try {
@@ -193,7 +158,7 @@ public class KettleAnalyzerUtil {
     } catch ( KettleException kve ) {
       // TODO throw exception or ignore?
     }
-    return resources;
+    return resources.getInternal();
   }
 
   public static TransMeta getSubTransMeta( final ISubTransAwareMeta meta ) throws MetaverseAnalyzerException {

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
@@ -1,0 +1,233 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.metaverse.api.analyzer.kettle;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith( PowerMockRunner.class )
+public class ExternalResourceCacheTest {
+
+  @Mock
+  private Trans trans;
+  @Mock
+  private Trans trans2;
+
+  @Mock
+  private TransMeta transMeta;
+
+  @Mock
+  private TransMeta transMeta2;
+
+  @Mock
+  private BaseFileInputMeta meta;
+
+  private StepMeta spyMeta;
+
+  @Before
+  public void setup() {
+    ExternalResourceCache.getInstance().transMap = new ConcurrentHashMap();
+    ExternalResourceCache.getInstance().resourceMap = new ConcurrentHashMap();
+  }
+
+  private void initMetas() {
+    spyMeta = spy( new StepMeta( "test", meta ) );
+    when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
+    when( meta.getParentStepMeta() ).thenReturn( spyMeta );
+    when( transMeta.getFilename() ).thenReturn( "my_file" );
+
+    when( trans.getTransMeta() ).thenReturn( transMeta );
+    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+
+    when( trans2.getTransMeta() ).thenReturn( transMeta2 );
+    when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+  }
+
+  @Test
+  public void test_getInstance() {
+    // verify that we have a singleton
+    assertEquals( ExternalResourceCache.getInstance(), ExternalResourceCache.getInstance() );
+  }
+
+  @Test
+  public void test_getUniqueId() {
+    assertNull( ExternalResourceCache.getInstance().getUniqueId( null ) );
+    // parent TransMeta is not yet mocked, we should get null back
+    assertNull( ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+
+    initMetas();
+
+    // null repo
+    assertEquals( System.getProperty( "user.dir" ) + File.separator + "my_file::test",
+      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+
+    // mock the repo
+    when( transMeta.getRepository() ).thenReturn( Mockito.mock( Repository.class ) );
+    assertEquals( "null.null::test",
+      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+
+    when( transMeta.getPathAndName() ).thenReturn( "path_and_name" );
+    when( transMeta.getDefaultExtension() ).thenReturn( "ktr" );
+    assertEquals( "path_and_name.ktr::test",
+      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+  }
+
+  @Test
+  public void test_caching() {
+    initMetas();
+
+    assertNull( ExternalResourceCache.getInstance().get( null, null ) );
+    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    assertNull( ExternalResourceCache.getInstance().get( trans, null ) );
+    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
+    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    // the cache contains sets, make sure another copy of the same trans is not added
+    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
+    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
+    List<ExternalResourceCache.TransValues> cachedTransformations = IteratorUtils.toList(
+      ExternalResourceCache.getInstance().transMap.values().iterator() );
+    assertEquals( 1, cachedTransformations.size() );
+    assertEquals( 1, cachedTransformations.get( 0 ).size() );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    assertNull( ExternalResourceCache.getInstance().get( trans2, meta ) );
+    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
+    cachedTransformations = IteratorUtils.toList(
+      ExternalResourceCache.getInstance().transMap.values().iterator() );
+    assertEquals( 1, cachedTransformations.size() );
+    assertEquals( 2, cachedTransformations.get( 0 ).size() );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    final ExternalResourceCache.ExternalResourceValues resources = ExternalResourceCache.getInstance()
+      .newExternalResourceValues();
+    resources.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    // cache some resources
+    ExternalResourceCache.getInstance().cache( trans, meta, resources );
+    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
+    cachedTransformations = IteratorUtils.toList(
+      ExternalResourceCache.getInstance().transMap.values().iterator() );
+    assertEquals( 1, cachedTransformations.size() );
+    assertEquals( 2, cachedTransformations.get( 0 ).size() );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
+    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    // remote trans from the cache
+    ExternalResourceCache.getInstance().removeCachedResources( trans );
+    // trans2 should still exist in the map
+    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
+    cachedTransformations = IteratorUtils.toList(
+      ExternalResourceCache.getInstance().transMap.values().iterator() );
+    assertEquals( 1, cachedTransformations.size() );
+    assertEquals( 1, cachedTransformations.get( 0 ).size() );
+    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
+    // resources should not be removed as they are still being used by trans2
+    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+
+    // remove trans2 from the cache
+    ExternalResourceCache.getInstance().removeCachedResources( trans2 );
+    // transMap and resourceMap should now both be empty
+    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
+    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+  }
+
+  @Test
+  public void test_ExternalResourceTransValues() {
+    final Trans trans1 = new Trans();
+    final Trans trans2 = new Trans();
+    final ExternalResourceCache.Resources transValues = ExternalResourceCache.getInstance().new TransValues();
+    assertEquals( 0, transValues.size() );
+    transValues.add( trans1 );
+    assertEquals( 1, transValues.size() );
+    assertTrue( transValues.contains( trans1 ) );
+    transValues.add( trans2 );
+    assertEquals( 2, transValues.size() );
+    assertTrue( transValues.contains( trans2 ) );
+
+    transValues.remove( trans1 );
+    assertEquals( 1, transValues.size() );
+    assertFalse( transValues.contains( trans1 ) );
+    assertTrue( transValues.contains( trans2 ) );
+    transValues.remove( trans2 );
+    assertEquals( 0, transValues.size() );
+
+    // make sure we're getting a copy, not the original
+    assertFalse( transValues.getInternal() == transValues.getInternal() );
+  }
+
+  @Test
+  public void test_ExternalResourceExternalResourceValues() {
+    final IExternalResourceInfo resource1 = Mockito.mock( IExternalResourceInfo.class );
+    final IExternalResourceInfo resource2 = Mockito.mock( IExternalResourceInfo.class );
+    final ExternalResourceCache.Resources resourceValues = ExternalResourceCache.getInstance().new
+      ExternalResourceValues();
+    assertEquals( 0, resourceValues.size() );
+    resourceValues.add( resource1 );
+    assertEquals( 1, resourceValues.size() );
+    assertTrue( resourceValues.contains( resource1 ) );
+    resourceValues.add( resource2 );
+    assertEquals( 2, resourceValues.size() );
+    assertTrue( resourceValues.contains( resource2 ) );
+
+    resourceValues.remove( resource1 );
+    assertEquals( 1, resourceValues.size() );
+    assertFalse( resourceValues.contains( resource1 ) );
+    assertTrue( resourceValues.contains( resource2 ) );
+    resourceValues.remove( resource2 );
+    assertEquals( 0, resourceValues.size() );
+
+    // make sure we're getting a copy, not the original
+    assertFalse( resourceValues.getInternal() == resourceValues.getInternal() );
+  }
+}

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtilTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtilTest.java
@@ -50,9 +50,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -244,39 +241,14 @@ public class KettleAnalyzerUtilTest {
   public void test_getResourcedFromMeta() throws Exception {
     initMetas();
     when( meta.isAcceptingFilenames() ).thenReturn( false );
-
-    Set<IExternalResourceInfo> resources = (Set<IExternalResourceInfo>) KettleAnalyzerUtil.getResourcesFromMeta( meta, filePaths );
+    Set<IExternalResourceInfo>
+      resources = (Set<IExternalResourceInfo>) KettleAnalyzerUtil.getResourcesFromMeta( meta, filePaths );
     assertFalse( resources.isEmpty() );
     assertEquals( 3, resources.size() );
-
-    Field resourceMapField = KettleAnalyzerUtil.class.getDeclaredField( "resourceMap" );
-    resourceMapField.setAccessible( true );
-
-    Map<String, Collection<IExternalResourceInfo>> resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 1, resourceMap.size() );
-    assertEquals( 3, resourceMap.get( KettleAnalyzerUtil.getUniqueId( meta.getParentStepMeta() ) ).size() );
 
     Set<IExternalResourceInfo> resources2 = (Set) KettleAnalyzerUtil.getResourcesFromMeta( meta2, filePaths2 );
     assertFalse( resources2.isEmpty() );
     assertEquals( 2, resources2.size() );
-    resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 2, resourceMap.size() );
-    assertEquals( 2, resourceMap.get( KettleAnalyzerUtil.getUniqueId( meta2.getParentStepMeta() ) ).size() );
-
-    // verify that resource removal form map works
-    KettleAnalyzerUtil.removeResources( spyMeta );
-    resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 1, resourceMap.size() );
-    KettleAnalyzerUtil.removeResources( spyMeta2 );
-    resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 0, resourceMap.size() );
   }
 
-  @Test
-  public void test_getUniqueId() {
-    initMetas();
-
-    assertEquals( System.getProperty( "user.dir" ) + File.separator + "my_file::test",
-      KettleAnalyzerUtil.getUniqueId( meta.getParentStepMeta() ) );
-  }
 }

--- a/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
+++ b/core/src/main/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMap.java
@@ -27,7 +27,7 @@ import org.pentaho.di.job.Job;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
-import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
+import org.pentaho.metaverse.api.analyzer.kettle.ExternalResourceCache;
 import org.pentaho.metaverse.api.model.LineageHolder;
 import org.pentaho.metaverse.util.MetaverseBeanUtil;
 
@@ -87,7 +87,7 @@ public class TransLineageHolderMap {
     final LineageHolder holder = lineageHolderMap.remove( t );
 
     // remove references to any external resources associated with this transformation, we no longer need them
-    KettleAnalyzerUtil.removeResources( t.getTransMeta() );
+    ExternalResourceCache.getInstance().removeCachedResources( t );
 
     for ( final Object subExecutable : holder.getSubTransAndJobs() ) {
       if ( subExecutable instanceof Trans ) {

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.reflect.Whitebox;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
@@ -36,13 +35,15 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageHolderMap;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
-import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
+import org.pentaho.metaverse.api.analyzer.kettle.ExternalResourceCache;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
 import org.pentaho.metaverse.api.model.LineageHolder;
+import org.powermock.reflect.Whitebox;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -94,8 +95,8 @@ public class JobLineageHolderMapTest {
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( KettleAnalyzerUtil.class, "resourceMap",
-            Collections.synchronizedMap( new MapMaker().weakValues().makeMap() ) );
+    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "transMap", new ConcurrentHashMap() );
+    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "resourceMap", new ConcurrentHashMap() );
     jobLineageHolderMap = JobLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
     jobLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
@@ -28,25 +28,30 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.reflect.Whitebox;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
+import org.pentaho.di.trans.steps.file.BaseFileInputStep;
 import org.pentaho.metaverse.analyzer.kettle.extensionpoints.job.JobLineageHolderMap;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.analyzer.kettle.ExternalResourceCache;
 import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.pentaho.metaverse.api.model.LineageHolder;
+import org.powermock.reflect.Whitebox;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -93,7 +98,13 @@ public class TransLineageHolderMapTest {
   private BaseFileInputMeta meta2;
 
   @Mock
+  private BaseFileInputStep input;
+
+  @Mock
   private TransMeta transMeta;
+
+  @Mock
+  private RowMetaInterface rowMetaInterface;
 
   private String path1 = "/path/to/file1";
   private String path1a = "/another/path/to/file1a";
@@ -128,6 +139,10 @@ public class TransLineageHolderMapTest {
     when( meta2.getFilePaths( false) ).thenReturn( filePaths2 );
 
     when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta, spyMeta2 } ) );
+
+    when( input.getStepMetaInterface() ).thenReturn( meta );
+    when( input.getStepMeta() ).thenReturn( spyMeta );
+    when( input.getTrans() ).thenReturn( trans );
   }
 
   @Before
@@ -136,8 +151,8 @@ public class TransLineageHolderMapTest {
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( KettleAnalyzerUtil.class, "resourceMap",
-            Collections.synchronizedMap( new MapMaker().weakValues().makeMap() ) );
+    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "transMap", new ConcurrentHashMap() );
+    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "resourceMap", new ConcurrentHashMap() );
     transLineageHolderMap = TransLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
     transLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );
@@ -186,7 +201,7 @@ public class TransLineageHolderMapTest {
   @Test
   public void testRemoveLineageHolderWithParentTrans() throws Exception {
     initMetas();
-    when( meta.isAcceptingFilenames() ).thenReturn( false );
+    when( meta.isAcceptingFilenames() ).thenReturn( true );
 
     // initialize the lineage holder for this transformation
     transLineageHolderMap.getLineageHolder( trans );
@@ -194,42 +209,53 @@ public class TransLineageHolderMapTest {
     // test with parent transformation being set
     when( trans.getParentTrans() ).thenReturn( parentTrans );
 
-    KettleAnalyzerUtil.getResourcesFromMeta( meta, filePaths );
-    KettleAnalyzerUtil.getResourcesFromMeta( meta2, filePaths2 );
+    when( input.environmentSubstitute( Mockito.any( String.class ) ) ).thenReturn( "/path/to/row/file" );
 
-    Field resourceMapField = KettleAnalyzerUtil.class.getDeclaredField( "resourceMap" );
+    KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
+
+    Field resourceMapField = ExternalResourceCache.class.getDeclaredField( "resourceMap" );
     resourceMapField.setAccessible( true );
+    Field transMapField = ExternalResourceCache.class.getDeclaredField( "transMap" );
+    transMapField.setAccessible( true );
 
-    Map<String, Collection<IExternalResourceInfo>> resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 2, resourceMap.size() );
+    Map<String, ExternalResourceCache.ExternalResourceValues> resourceMap = (Map) resourceMapField.get(
+      ExternalResourceCache.getInstance() );
+    Map<String, ExternalResourceCache.ExternalResourceValues> transMap = (Map) transMapField.get(
+      ExternalResourceCache.getInstance() );
+    assertEquals( 1, resourceMap.size() );
+    assertEquals( 1, transMap.size() );
 
     Field lineageHolderMapField = transLineageHolderMap.getClass().getDeclaredField( "lineageHolderMap" );
     lineageHolderMapField.setAccessible( true );
 
     transLineageHolderMap.removeLineageHolder( trans );
     // make sure the trans map entry was NOT removed and its resources were NOT removed from the
-    // KettleAnalyzerUtil.resourceMap, since trans has a parent
-    resourceMap = (Map) resourceMapField.get( null );
+    // ExternalResourceCache, since trans has a parent
+    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
+    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     Map<Trans, LineageHolder> lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNotNull( lineageHolderMap.get( trans ) );
-    assertEquals( 2, resourceMap.size() );
+    assertEquals( 1, resourceMap.size() ); // the resource map has only one resource
+    assertEquals( 1, transMap.size() );
     assertEquals( 2, lineageHolderMap.size() );
 
     // make sure that removing the parent trans removes it and its sub-transformations from the map and also removed
-    // sub-transformation resources from KettleAnalyzerUtil.resourceMap
+    // sub-transformation resources from ExternalResourceCache
     transLineageHolderMap.removeLineageHolder( parentTrans );
-    resourceMap = (Map) resourceMapField.get( null );
+    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
+    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNull( lineageHolderMap.get( parentTrans ) );
     assertNull( lineageHolderMap.get( trans ) );
     assertEquals( 0, resourceMap.size() );
+    assertEquals( 0, transMap.size() );
     assertEquals( 0, lineageHolderMap.size() );
   }
 
   @Test
   public void testRemoveLineageHolderWithParentJob() throws Exception {
     initMetas();
-    when( meta.isAcceptingFilenames() ).thenReturn( false );
+    when( meta.isAcceptingFilenames() ).thenReturn( true );
 
     // initialize the lineage holder for this transformation
     transLineageHolderMap.getLineageHolder( trans );
@@ -237,36 +263,47 @@ public class TransLineageHolderMapTest {
     // test with parent transformation being set
     when( trans.getParentJob() ).thenReturn( parentJob );
 
-    KettleAnalyzerUtil.getResourcesFromMeta( meta, filePaths );
-    KettleAnalyzerUtil.getResourcesFromMeta( meta2, filePaths2 );
+    when( input.environmentSubstitute( Mockito.any( String.class ) ) ).thenReturn( "/path/to/row/file" );
 
-    Field resourceMapField = KettleAnalyzerUtil.class.getDeclaredField( "resourceMap" );
+    KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
+
+    Field resourceMapField = ExternalResourceCache.class.getDeclaredField( "resourceMap" );
     resourceMapField.setAccessible( true );
+    Field transMapField = ExternalResourceCache.class.getDeclaredField( "transMap" );
+    transMapField.setAccessible( true );
 
-    Map<String, Collection<IExternalResourceInfo>> resourceMap = (Map) resourceMapField.get( null );
-    assertEquals( 2, resourceMap.size() );
+    Map<String, Collection<IExternalResourceInfo>> resourceMap = (Map) resourceMapField.get(
+      ExternalResourceCache.getInstance() );
+    Map<String, ExternalResourceCache.ExternalResourceValues> transMap = (Map) transMapField.get(
+      ExternalResourceCache.getInstance() );
+    assertEquals( 1, resourceMap.size() );
+    assertEquals( 1, transMap.size() );
 
     Field lineageHolderMapField = transLineageHolderMap.getClass().getDeclaredField( "lineageHolderMap" );
     lineageHolderMapField.setAccessible( true );
 
     transLineageHolderMap.removeLineageHolder( trans );
     // make sure the trans map entry was NOT removed and its resources were NOT removed from the
-    // KettleAnalyzerUtil.resourceMap, since trans has a parent
-    resourceMap = (Map) resourceMapField.get( null );
+    // ExternalResourceCache, since trans has a parent
+    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
+    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     Map<Trans, LineageHolder> lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNotNull( lineageHolderMap.get( trans ) );
-    assertEquals( 2, resourceMap.size() );
+    assertEquals( 1, resourceMap.size() ); // the resource map has only one resource
+    assertEquals( 1, transMap.size() );
     // lineageHolderMap will only have one member, the parent job will be in the JobLineageHolderMap
     assertEquals( 1, lineageHolderMap.size() );
 
     // make sure that removing the parent trans removes it and its sub-transformations from the map and also removed
     // sub-transformation resources from KettleAnalyzerUtil.resourceMap
     JobLineageHolderMap.getInstance().removeLineageHolder( parentJob );
-    resourceMap = (Map) resourceMapField.get( null );
+    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
+    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNull( lineageHolderMap.get( parentJob ) );
     assertNull( lineageHolderMap.get( trans ) );
     assertEquals( 0, resourceMap.size() );
+    assertEquals( 0, transMap.size() );
     assertEquals( 0, lineageHolderMap.size() );
   }
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fileinput/text/TextFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fileinput/text/TextFileInputStepAnalyzerTest.java
@@ -179,10 +179,8 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     when( meta.isAcceptingFilenames() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( meta ) );
     resources = consumer.getResourcesFromMeta( meta );
-    // resources will have been cached from the previous call to getResourcesFromMeta, so a call to
-    // getResourcesFromMeta will return 2 resources, even though we are accepting files from filename
-    assertFalse( resources.isEmpty() );
-    assertEquals( 2, resources.size() );
+    // call to getResourcesFromMeta does not cache resources, only calls to getResourcesFromRow do
+    assertTrue( resources.isEmpty() );
 
     when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
       .thenReturn( "/path/to/row/file" );
@@ -190,16 +188,14 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
     resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
-    // resources will have been cached from the previous call to getResourcesFromMeta, so a call to
-    // getResourcesFromRow will return those 2 resources, as well as those from row
-    assertEquals( 3, resources.size() );
+    assertEquals( 1, resources.size() );
 
     when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
       .thenThrow( KettleException.class );
     resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     // even when the call to getString throws an exception, we can still get resources from the cache
     assertFalse( resources.isEmpty() );
-    assertEquals( 3, resources.size() );
+    assertEquals( 1, resources.size() );
 
     assertEquals( TextFileInputMeta.class, consumer.getMetaClass() );
   }

--- a/core/src/test/resources/com/pentaho/metaverse/messages/messages.properties
+++ b/core/src/test/resources/com/pentaho/metaverse/messages/messages.properties
@@ -41,6 +41,7 @@ ERROR.CouldNotParseDateFromString=Could not parse date from string: {0}
 ERROR.FailedAddingFileToZip=Failed to add file to the zip: {0}
 ERROR.FailedToProperlyCloseZipEntry=Failed to close the zip entry for file: {0}
 ERROR.NoPathFound=No path property was found in the body of the request
+ERROR.NotATransOrJob=Attempting to add an object to the list that is not a Transformation or a Job
 
 WARNING.NoMatchingDocumentAnalyzerFound=No DocumentAnalyzer found that handles documents of type {0}.
 WARNING.AddingNodesCreated=There was a problem trying to add nodes created by a step.


### PR DESCRIPTION
The previous implementation did not account for the fact that the same resources might be re-used by multiple transformations running at the same time, and the cache was being cleared prematurely. Additionally, the map would occasionally get cleared (possibly through GC?)