### PR TITLE
[BACKLOG-27250] Removes unused pentaho-platform-core-tests dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -227,13 +227,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-platform-core</artifactId>
-      <version>${platform.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>${dependency.commons-cli.version}</version>


### PR DESCRIPTION
@pentaho/rogueone Please review

Related PRs: