### PR TITLE
[SP-5370] Backport of PDI-17775 - Process Files step no longer suppor…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,6 @@
     <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <dependency.com.tinkerpop.pipes.version>2.6.0</dependency.com.tinkerpop.pipes.version>
     <commons-collections.version>3.2.2</commons-collections.version>
   </properties>
@@ -102,7 +101,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.tinkerpop</groupId>

--- a/core/src/main/java/org/pentaho/metaverse/util/VfsDateRangeFilter.java
+++ b/core/src/main/java/org/pentaho/metaverse/util/VfsDateRangeFilter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -100,8 +100,8 @@ public class VfsDateRangeFilter extends FileDepthSelector {
 
   @Override
   public boolean includeFile( FileSelectInfo fileInfo ) {
-    boolean result = super.includeFile( fileInfo );
     try {
+      boolean result = super.includeFile( fileInfo );
       if ( fileInfo.getFile().getType() == FileType.FOLDER ) {
 
         Date folderDate = format.parse( fileInfo.getFile().getName().getBaseName() );
@@ -122,8 +122,9 @@ public class VfsDateRangeFilter extends FileDepthSelector {
       } else {
         return false;
       }
-    } catch ( ParseException | FileSystemException e ) {
+    } catch ( Exception e ) {
       // folder name is not a valid date string, reject it
+      // [PDI-17775] Doing a full exception catch due to the extended class throwing a general exception
       return false;
     }
   }


### PR DESCRIPTION
…ts HTTP scheme (9.0 Suite)

Cherry pick from: https://github.com/pentaho/pentaho-metaverse/pull/614

This PR is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/220
- https://github.com/pentaho/apache-vfs-browser/pull/61
- https://github.com/pentaho/big-data-plugin/pull/2035
- https://github.com/webdetails/cpk/pull/86
- https://github.com/pentaho/data-access/pull/1090
- https://github.com/pentaho/mondrian/pull/1197
- https://github.com/pentaho/pdi-jms-plugin/pull/75
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/103
- https://github.com/pentaho/pdi-plugins-ee/pull/170
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/83
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/52
- https://github.com/pentaho/pentaho-big-data-ee/pull/442
- https://github.com/pentaho/pentaho-commons-database/pull/178
- https://github.com/pentaho/pentaho-data-mining/pull/25
- https://github.com/pentaho/pentaho-det-ee/pull/615
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/22
- https://github.com/pentaho/pentaho-karaf-assembly/pull/634
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/286
- https://github.com/pentaho/pentaho-kettle/pull/7313
- https://github.com/pentaho/pentaho-metaverse/pull/620
- https://github.com/pentaho/pentaho-osgi-bundles/pull/362
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1503
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/340
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/789
- https://github.com/pentaho/pentaho-platform/pull/4651
- https://github.com/pentaho/pentaho-reporting/pull/1328
- https://github.com/pentaho/pentaho-s3-vfs/pull/93
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/16