### PR TITLE
[PDI-18657] Memory leak when customer executes jobs on the server

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -127,5 +127,17 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-platform-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
@@ -47,4 +47,8 @@ public interface IMetaverseConfig {
   void setConsolidateSubGraphs( final boolean consolidateGraphs );
 
   boolean getConsolidateSubGraphs();
+
+  void setExternalResourceCacheExpireTime( final String cacheExpire );
+
+  String getExternalResourceCacheExpireTime();
 }

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.metaverse.api.analyzer.kettle;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,17 +32,21 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
+import org.pentaho.metaverse.api.IMetaverseConfig;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
 
 @RunWith( PowerMockRunner.class )
 public class ExternalResourceCacheTest {
@@ -62,131 +65,117 @@ public class ExternalResourceCacheTest {
   private TransMeta transMeta;
 
   @Mock
-  private BaseFileInputMeta meta;
+  private BaseFileInputMeta meta1;
 
-  private StepMeta spyMeta;
+  @Mock
+  private BaseFileInputMeta meta2;
 
-  @Before
-  public void setup() {
-    ExternalResourceCache.getInstance().transMap = new ConcurrentHashMap();
-    ExternalResourceCache.getInstance().resourceMap = new ConcurrentHashMap();
-  }
+  private StepMeta spyMeta1;
+
+  private StepMeta spyMeta2;
+
+  private ExternalResourceCache testInstance;
 
   private void initMetas() {
-    spyMeta = spy( new StepMeta( "test", meta ) );
-    when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta.getParentStepMeta() ).thenReturn( spyMeta );
+    spyMeta1 = spy( new StepMeta( "test", meta1) );
+    when( spyMeta1.getParentTransMeta() ).thenReturn( transMeta );
+    when( meta1.getParentStepMeta() ).thenReturn(spyMeta1);
     when( transMeta.getFilename() ).thenReturn( "my_file" );
+
+    spyMeta2 = spy( new StepMeta( "test2", meta2) );
+    when( spyMeta2.getParentTransMeta() ).thenReturn( transMeta2 );
+    when( meta2.getParentStepMeta() ).thenReturn(spyMeta2);
+    when( transMeta2.getFilename() ).thenReturn( "my_file2" );
 
     when( trans.getName() ).thenReturn( "my_trans" );
     when( trans.getFilename() ).thenReturn( "my_file" );
 
     when( trans.getTransMeta() ).thenReturn( transMeta );
-    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta1} ) );
 
     when( trans2.getTransMeta() ).thenReturn( transMeta2 );
     when( trans2.getName() ).thenReturn( "my_trans2" );
     when( trans2.getFilename() ).thenReturn( "my_file2" );
-    when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+    when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta2} ) );
+  }
+
+  @Before
+  public void setup() {
+    testInstance = new ExternalResourceCache(null );
   }
 
   @Test
   public void test_getInstance() {
+    assertNotNull( ExternalResourceCache.getInstance() );
     // verify that we have a singleton
     assertEquals( ExternalResourceCache.getInstance(), ExternalResourceCache.getInstance() );
   }
 
   @Test
   public void test_getUniqueId() {
-    assertNull( ExternalResourceCache.getInstance().getUniqueId( null ) );
+    assertNull( testInstance.getUniqueId( null ) );
     // parent TransMeta is not yet mocked, we should get null back
-    assertNull( ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+    assertNull( testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     initMetas();
 
     // null repo
     assertEquals( System.getProperty( "user.dir" ) + File.separator + "my_file::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     // mock the repo
     when( transMeta.getRepository() ).thenReturn( Mockito.mock( Repository.class ) );
     assertEquals( "null.null::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     when( transMeta.getPathAndName() ).thenReturn( "path_and_name" );
     when( transMeta.getDefaultExtension() ).thenReturn( "ktr" );
     assertEquals( "path_and_name.ktr::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
   }
 
   @Test
   public void test_caching() {
     initMetas();
 
-    assertNull( ExternalResourceCache.getInstance().get( null, null ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( null, null ) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    assertNull( ExternalResourceCache.getInstance().get( trans, null ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( trans, null ) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( trans, meta1) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    // the cache contains sets, make sure another copy of the same trans is not added
-    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    List<ExternalResourceCache.TransValues> cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 1, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( trans2, meta2) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    assertNull( ExternalResourceCache.getInstance().get( trans2, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 2, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
-
-    final ExternalResourceCache.ExternalResourceValues resources = ExternalResourceCache.getInstance()
+    final ExternalResourceCache.ExternalResourceValues resources1 = testInstance
       .newExternalResourceValues();
-    resources.add( Mockito.mock( IExternalResourceInfo.class ) );
+    resources1.add( Mockito.mock( IExternalResourceInfo.class ) );
 
-    // cache some resources
-    ExternalResourceCache.getInstance().cache( trans, meta, resources );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 2, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+    final ExternalResourceCache.ExternalResourceValues resources2 = testInstance
+      .newExternalResourceValues();
+    resources2.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    // cache some resources1
+    testInstance.cache( trans, meta1, resources1 );
+    assertEquals( 1, testInstance.resourceCache.size() );
+
+    // cache some resources2
+    testInstance.cache( trans2, meta2, resources2 );
+    assertEquals( 2, testInstance.resourceCache.size() );
 
     // remote trans from the cache
-    ExternalResourceCache.getInstance().removeCachedResources( trans );
-    // trans2 should still exist in the map
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 1, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    // resources should not be removed as they are still being used by trans2
-    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+    testInstance.removeCachedResources( trans );
+    assertEquals( 1, testInstance.resourceCache.size() );
+    assertNull( testInstance.get( trans, meta1 ) );
+    assertEquals( resources2, testInstance.get( trans2, meta2 ) );
 
     // remove trans2 from the cache
-    ExternalResourceCache.getInstance().removeCachedResources( trans2 );
-    // transMap and resourceMap should now both be empty
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    testInstance.removeCachedResources( trans2 );
+    assertNull( testInstance.get( trans2, meta2 ) );
+    assertEquals( 0, testInstance.resourceCache.size() );
   }
 
   @Test
@@ -250,5 +239,60 @@ public class ExternalResourceCacheTest {
 
     // make sure we're getting a copy, not the original
     assertFalse( resourceValues.getInternal() == resourceValues.getInternal() );
+  }
+
+  @Test
+  public void test_caching_timeout() throws Exception {
+    long timeout = 125; // small timeout
+    IMetaverseConfig metaverseConfig = mock( IMetaverseConfig.class );
+    when( metaverseConfig.getExternalResourceCacheExpireTime() ).thenReturn( "1" );
+    testInstance = new ExternalResourceCache( metaverseConfig );
+
+
+    initMetas();
+
+    final ExternalResourceCache.ExternalResourceValues resources1 = testInstance
+      .newExternalResourceValues();
+    resources1.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    final ExternalResourceCache.ExternalResourceValues resources2 = testInstance
+      .newExternalResourceValues();
+    resources2.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    // verify nothing in cache
+    assertNull( testInstance.get( trans, meta1 ) );
+    assertNull( testInstance.get( trans2, meta2 ) );
+
+    // add items
+    testInstance.cache( trans, meta1, resources1 );
+    testInstance.cache( trans2, meta2, resources2 );
+    assertEquals( resources1, testInstance.get( trans, meta1 ) );
+    assertEquals( resources2, testInstance.get( trans2, meta2 ) );
+
+    // sleep
+    Thread.sleep( 2000  );
+
+    // verify
+    assertNull( testInstance.get( trans, meta1 ) );
+    assertNull( testInstance.get( trans2, meta2 ) );
+  }
+
+  @Test
+  public void test_GetCacheExpireTime() throws Exception {
+
+    // TEST1 : config null
+    assertEquals( ExternalResourceCache.DEFAULT_TIMEOUT_SECONDS, testInstance.getCacheExpireTime( null ) );
+
+    // TEST2: config expireTime value is null
+    IMetaverseConfig metaverseConfig1 = mock( IMetaverseConfig.class );
+    when( metaverseConfig1.getExternalResourceCacheExpireTime() ).thenReturn( null );
+    assertEquals( ExternalResourceCache.DEFAULT_TIMEOUT_SECONDS, testInstance.getCacheExpireTime( metaverseConfig1 ) );
+
+    // TEST3:
+    long expireTime = 423L;
+    IMetaverseConfig metaverseConfig2 = mock( IMetaverseConfig.class );
+    when( metaverseConfig2.getExternalResourceCacheExpireTime() ).thenReturn( Long.toString( expireTime ) );
+    assertEquals( expireTime, testInstance.getCacheExpireTime( metaverseConfig2 ) );
+
   }
 }

--- a/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
@@ -33,6 +33,7 @@ public class MetaverseConfig implements IMetaverseConfig {
   private String executionRuntime = "off";
   private String extecutionOutputFolder = "./pentaho-lineage-output";
   private String executionGenerationStrategy = "latest";
+  private String externalResourceCacheExpireTime = "21600";
   private boolean resolveExternalResources = true;
   private boolean deduplicateTransformationFields = true;
   private boolean adjustExternalResourceFields = true;
@@ -132,6 +133,14 @@ public class MetaverseConfig implements IMetaverseConfig {
 
   public boolean getConsolidateSubGraphs() {
     return this.consolidateSubGraphs;
+  }
+
+  public void setExternalResourceCacheExpireTime( final String externalResourceCacheExpireTime ) {
+    this.externalResourceCacheExpireTime = externalResourceCacheExpireTime;
+  }
+
+  public String getExternalResourceCacheExpireTime() {
+    return this.externalResourceCacheExpireTime;
   }
 
   public static boolean consolidateSubGraphs() {

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,7 @@
       <cm:property name="lineage.adjust.external.resource.fields" value="true"/>
       <cm:property name="lineage.generate.subgraphs" value="true"/>
       <cm:property name="lineage.consolidate.subgraphs" value="true"/>
+      <cm:property name="lineage.external.resource.cache.expire.time" value="21600"/>
       <!-- Used for testing ONLY - write delay in seconds -->
       <cm:property name="lineage.delay" value="0"/>
     </cm:default-properties>
@@ -42,6 +43,7 @@
     <property name="adjustExternalResourceFields" value="${lineage.adjust.external.resource.fields}"/>
     <property name="generateSubGraphs" value="${lineage.generate.subgraphs}"/>
     <property name="consolidateSubGraphs" value="${lineage.consolidate.subgraphs}"/>
+    <property name="externalResourceCacheExpireTime" value="${lineage.external.resource.cache.expire.time}"/>
     <!-- Used for testing ONLY - write delay in seconds -->
     <property name="lineageDelay" value="${lineage.delay}"/>
   </bean>


### PR DESCRIPTION
 - removed inconsequential transMap variable, TransValues defined
in ExternalResourceCache is not used externally
 - modified caching with eviction by time