### PR TITLE
[PPP-4481] Use of Vulnerable Component: Components/h2-1.2.131.jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -263,12 +263,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>1.3.171</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-core</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Removing unused `com.h2database:h2` dependency.

See https://github.com/pentaho/maven-parent-poms/pull/245 for more details.