### PR TITLE
[SP-5701] Backport of PDI-18657 Memory leak when customer executes jo…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,7 +44,7 @@
         <exclusion>
           <artifactId>jackson-jaxrs</artifactId>
           <groupId>org.codehaus.jackson</groupId>
-        </exclusion>		
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -118,6 +118,25 @@
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
       <version>${dependency.org.powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-platform-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/IMetaverseConfig.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -47,4 +47,8 @@ public interface IMetaverseConfig {
   void setConsolidateSubGraphs( final boolean consolidateGraphs );
 
   boolean getConsolidateSubGraphs();
+
+  void setExternalResourceCacheExpireTime( final String cacheExpire );
+
+  String getExternalResourceCacheExpireTime();
 }

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
@@ -22,12 +22,16 @@
 
 package org.pentaho.metaverse.api.analyzer.kettle;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metaverse.api.IMetaverseConfig;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A cache of resources encountered when a transformation is run that can be used to access these run-time resources at
@@ -45,9 +49,9 @@ public class ExternalResourceCache {
 
   private static final Logger log = LoggerFactory.getLogger( ExternalResourceCache.class );
 
-  protected volatile Map<String, TransValues> transMap = new ConcurrentHashMap();
+  protected static final long DEFAULT_TIMEOUT_SECONDS = 6L * 60 * 60; // 6 hours
 
-  protected volatile Map<String, ExternalResourceValues> resourceMap = new ConcurrentHashMap();
+  protected Cache<String, ExternalResourceValues> resourceCache;
 
   private static ExternalResourceCache INSTANCE;
 
@@ -63,6 +67,22 @@ public class ExternalResourceCache {
   }
 
   private ExternalResourceCache() {
+    this( PentahoSystem.get( IMetaverseConfig.class ) );
+  }
+
+  protected ExternalResourceCache( IMetaverseConfig config ) {
+    long cacheExpireTime = getCacheExpireTime( config );
+    initCache( cacheExpireTime, TimeUnit.SECONDS );
+  }
+
+  protected long getCacheExpireTime( IMetaverseConfig config ) {
+    String expireTime = ( config != null ) ? config.getExternalResourceCacheExpireTime() : null;
+    return ( expireTime != null ) ? Long.parseLong( expireTime ) : DEFAULT_TIMEOUT_SECONDS;
+  }
+
+  void initCache( long time, TimeUnit timeUnit ) {
+    resourceCache = CacheBuilder.newBuilder().expireAfterAccess( time, timeUnit ).build();
+    log.debug( "{} cache expire time set to {} {}", this.getClass().getSimpleName(), time, timeUnit );
   }
 
   protected String getUniqueId( final StepMeta meta ) {
@@ -85,61 +105,39 @@ public class ExternalResourceCache {
     final List<StepMeta> steps = transMeta.getSteps();
     for ( final StepMeta step : steps ) {
       final String uniqueMetaId = getUniqueId( step );
-
-      Resources<Trans> transformations = transMap.get( uniqueMetaId );
-      if ( transformations != null && transformations.contains( trans ) ) {
-        transformations.remove( trans );
-      }
-      // are there any other potentially running transformations that might be using this resource? If not, the
-      // resource can be removed, otherwise keep it
-      if ( transformations == null || transformations.size() == 0 ) {
-        resourceMap.remove( uniqueMetaId );
-        transMap.remove( uniqueMetaId );
-      }
+      resourceCache.invalidate( uniqueMetaId );
     }
   }
 
-  public Resources<IExternalResourceInfo> get( final Trans trans, final BaseStepMeta meta ) {
+  public Resources<IExternalResourceInfo> get( final BaseStepMeta meta ) {
     if ( meta == null ) {
       return null;
     }
-    cacheTrans( trans, meta );
     final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
-    return resourceMap.get( uniqueMetaId );
-  }
-
-  private void cacheTrans( final Trans trans, final BaseStepMeta meta ) {
-    if ( trans != null ) {
-      final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
-      TransValues transformations = transMap.get( uniqueMetaId );
-      if ( transformations == null ) {
-        transformations = new TransValues();
-        transMap.put( uniqueMetaId, transformations );
-      }
-      transformations.add( trans );
+    synchronized ( this ) {
+      return resourceCache.getIfPresent( uniqueMetaId );
     }
   }
 
-  public void cache( final Trans trans, final BaseStepMeta meta, final ExternalResourceValues resources ) {
-    cacheTrans( trans, meta );
+  public void cache( final BaseStepMeta meta, final ExternalResourceValues resources ) {
     final String uniqueMetaId = getUniqueId( meta.getParentStepMeta() );
-    resourceMap.put( uniqueMetaId, resources );
+    synchronized ( this ) {
+      resourceCache.put( uniqueMetaId, resources );
+    }
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
 
-    for ( Map.Entry<String, ExternalResourceValues> entry : resourceMap.entrySet() ) {
-      sb.append( " ---- " + entry.getKey() + ": " + entry.getValue().size() + "\n" );
-      sb.append( entry.getValue().toString() );
-    }
-    for ( Map.Entry<String, TransValues> entry : transMap.entrySet() ) {
-      sb.append( " ---- " + entry.getKey() + ": " + entry.getValue().size() + "\n" );
-      sb.append( entry.getValue().toString() );
+    if ( resourceCache != null ) {
+      for ( Map.Entry<String, ExternalResourceValues> entry : resourceCache.asMap().entrySet() ) {
+        sb.append( " ---- " + entry.getKey() + ": " + entry.getValue().size() + "\n" );
+        sb.append( entry.getValue().toString() );
+      }
     }
 
-    log.debug( "\n" + sb.toString() );
+    log.debug( "\n {}", sb );
     return sb.toString();
   }
 
@@ -159,19 +157,6 @@ public class ExternalResourceCache {
       return sb.toString();
     }
 
-  }
-
-  public class TransValues extends Resources<Trans> {
-
-    @Override
-    public void add( final Trans value ) {
-      for ( Trans t : internal ) {
-        if ( t.getTransMeta().equals( value.getTransMeta() ) ) {
-          return;
-        }
-      }
-      super.add( value );
-    }
   }
 
   /**

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java
@@ -109,7 +109,7 @@ public class KettleAnalyzerUtil {
   public static Collection<IExternalResourceInfo> getResourcesFromMeta(
     final BaseStepMeta meta, final String[] filePaths ) {
 
-    ExternalResourceCache.Resources resources = rowResourceCache.get( null, meta );
+    ExternalResourceCache.Resources resources = rowResourceCache.get( meta );
     if ( resources == null ) {
       resources = rowResourceCache.newExternalResourceValues();
     }
@@ -144,10 +144,10 @@ public class KettleAnalyzerUtil {
       meta = (BaseFileInputMeta) step.getStepMeta().getStepMetaInterface();
     }
     ExternalResourceCache.ExternalResourceValues resources =
-      (ExternalResourceCache.ExternalResourceValues) rowResourceCache.get( step.getTrans(), meta );
+      (ExternalResourceCache.ExternalResourceValues) rowResourceCache.get( meta );
     if ( resources == null ) {
       resources = rowResourceCache.newExternalResourceValues();
-      rowResourceCache.cache( step.getTrans(), meta, resources );
+      rowResourceCache.cache( meta, resources );
     }
 
     try {

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.metaverse.api.analyzer.kettle;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,17 +32,21 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
+import org.pentaho.metaverse.api.IMetaverseConfig;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
 
 @RunWith( PowerMockRunner.class )
 public class ExternalResourceCacheTest {
@@ -62,169 +65,114 @@ public class ExternalResourceCacheTest {
   private TransMeta transMeta;
 
   @Mock
-  private BaseFileInputMeta meta;
+  private BaseFileInputMeta meta1;
 
-  private StepMeta spyMeta;
+  @Mock
+  private BaseFileInputMeta meta2;
 
-  @Before
-  public void setup() {
-    ExternalResourceCache.getInstance().transMap = new ConcurrentHashMap();
-    ExternalResourceCache.getInstance().resourceMap = new ConcurrentHashMap();
-  }
+  private StepMeta spyMeta1;
+
+  private StepMeta spyMeta2;
+
+  private ExternalResourceCache testInstance;
 
   private void initMetas() {
-    spyMeta = spy( new StepMeta( "test", meta ) );
-    when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta.getParentStepMeta() ).thenReturn( spyMeta );
+    spyMeta1 = spy( new StepMeta( "test", meta1) );
+    when( spyMeta1.getParentTransMeta() ).thenReturn( transMeta );
+    when( meta1.getParentStepMeta() ).thenReturn(spyMeta1);
     when( transMeta.getFilename() ).thenReturn( "my_file" );
+
+    spyMeta2 = spy( new StepMeta( "test2", meta2) );
+    when( spyMeta2.getParentTransMeta() ).thenReturn( transMeta2 );
+    when( meta2.getParentStepMeta() ).thenReturn(spyMeta2);
+    when( transMeta2.getFilename() ).thenReturn( "my_file2" );
 
     when( trans.getName() ).thenReturn( "my_trans" );
     when( trans.getFilename() ).thenReturn( "my_file" );
 
     when( trans.getTransMeta() ).thenReturn( transMeta );
-    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta1} ) );
 
     when( trans2.getTransMeta() ).thenReturn( transMeta2 );
     when( trans2.getName() ).thenReturn( "my_trans2" );
     when( trans2.getFilename() ).thenReturn( "my_file2" );
-    when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta } ) );
+    when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta2} ) );
+  }
+
+  @Before
+  public void setup() {
+    testInstance = new ExternalResourceCache(null );
   }
 
   @Test
   public void test_getInstance() {
+    assertNotNull( ExternalResourceCache.getInstance() );
     // verify that we have a singleton
     assertEquals( ExternalResourceCache.getInstance(), ExternalResourceCache.getInstance() );
   }
 
   @Test
   public void test_getUniqueId() {
-    assertNull( ExternalResourceCache.getInstance().getUniqueId( null ) );
+    assertNull( testInstance.getUniqueId( null ) );
     // parent TransMeta is not yet mocked, we should get null back
-    assertNull( ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+    assertNull( testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     initMetas();
 
     // null repo
     assertEquals( System.getProperty( "user.dir" ) + File.separator + "my_file::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     // mock the repo
     when( transMeta.getRepository() ).thenReturn( Mockito.mock( Repository.class ) );
     assertEquals( "null.null::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
 
     when( transMeta.getPathAndName() ).thenReturn( "path_and_name" );
     when( transMeta.getDefaultExtension() ).thenReturn( "ktr" );
     assertEquals( "path_and_name.ktr::test",
-      ExternalResourceCache.getInstance().getUniqueId( meta.getParentStepMeta() ) );
+      testInstance.getUniqueId( meta1.getParentStepMeta() ) );
   }
 
   @Test
   public void test_caching() {
     initMetas();
 
-    assertNull( ExternalResourceCache.getInstance().get( null, null ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( null ) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    assertNull( ExternalResourceCache.getInstance().get( trans, null ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( meta1) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
+    assertNull( testInstance.get( meta2) );
+    assertEquals( 0, testInstance.resourceCache.size() );
 
-    // the cache contains sets, make sure another copy of the same trans is not added
-    assertNull( ExternalResourceCache.getInstance().get( trans, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    List<ExternalResourceCache.TransValues> cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 1, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
-
-    assertNull( ExternalResourceCache.getInstance().get( trans2, meta ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 2, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
-
-    final ExternalResourceCache.ExternalResourceValues resources = ExternalResourceCache.getInstance()
+    final ExternalResourceCache.ExternalResourceValues resources1 = testInstance
       .newExternalResourceValues();
-    resources.add( Mockito.mock( IExternalResourceInfo.class ) );
+    resources1.add( Mockito.mock( IExternalResourceInfo.class ) );
 
-    // cache some resources
-    ExternalResourceCache.getInstance().cache( trans, meta, resources );
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 2, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans ) );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+    final ExternalResourceCache.ExternalResourceValues resources2 = testInstance
+      .newExternalResourceValues();
+    resources2.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    // cache some resources1
+    testInstance.cache( meta1, resources1 );
+    assertEquals( 1, testInstance.resourceCache.size() );
+
+    // cache some resources2
+    testInstance.cache( meta2, resources2 );
+    assertEquals( 2, testInstance.resourceCache.size() );
 
     // remote trans from the cache
-    ExternalResourceCache.getInstance().removeCachedResources( trans );
-    // trans2 should still exist in the map
-    assertEquals( 1, ExternalResourceCache.getInstance().transMap.size() );
-    cachedTransformations = IteratorUtils.toList(
-      ExternalResourceCache.getInstance().transMap.values().iterator() );
-    assertEquals( 1, cachedTransformations.size() );
-    assertEquals( 1, cachedTransformations.get( 0 ).size() );
-    assertTrue( cachedTransformations.get( 0 ).contains( trans2 ) );
-    // resources should not be removed as they are still being used by trans2
-    assertEquals( 1, ExternalResourceCache.getInstance().resourceMap.size() );
+    testInstance.removeCachedResources( trans );
+    assertEquals( 1, testInstance.resourceCache.size() );
+    assertNull( testInstance.get( meta1 ) );
+    assertEquals( resources2, testInstance.get( meta2 ) );
 
     // remove trans2 from the cache
-    ExternalResourceCache.getInstance().removeCachedResources( trans2 );
-    // transMap and resourceMap should now both be empty
-    assertEquals( 0, ExternalResourceCache.getInstance().transMap.size() );
-    assertEquals( 0, ExternalResourceCache.getInstance().resourceMap.size() );
-  }
-
-  @Test
-  public void test_ExternalResourceTransValues() {
-    final Trans trans1 = new Trans();
-    trans1.setTransMeta( transMeta1 );
-    when( transMeta1.getName() ).thenReturn( "trans1file" );
-    when( transMeta1.getFilename() ).thenReturn( "trans1file.ktr" );
-
-    final Trans trans2 = new Trans();
-    trans2.setTransMeta( transMeta2 );
-    when( transMeta2.getName() ).thenReturn( "trans2file" );
-    when( transMeta2.getFilename() ).thenReturn( "trans2file.ktr" );
-
-    final Trans trans3 = new Trans();
-    trans3.setTransMeta( transMeta1 );
-
-    final ExternalResourceCache.Resources transValues = ExternalResourceCache.getInstance().new TransValues();
-    assertEquals( 0, transValues.size() );
-    transValues.add( trans1 );
-    assertEquals( 1, transValues.size() );
-    assertTrue( transValues.contains( trans1 ) );
-    transValues.add( trans2 );
-    assertEquals( 2, transValues.size() );
-    assertTrue( transValues.contains( trans2 ) );
-    transValues.add( trans3 );
-    assertEquals( 2, transValues.size() );
-    assertFalse( transValues.contains( trans3 ) );
-
-    transValues.remove( trans1 );
-    assertEquals( 1, transValues.size() );
-    assertFalse( transValues.contains( trans1 ) );
-    assertTrue( transValues.contains( trans2 ) );
-    transValues.remove( trans2 );
-    assertEquals( 0, transValues.size() );
-
-    // make sure we're getting a copy, not the original
-    assertFalse( transValues.getInternal() == transValues.getInternal() );
+    testInstance.removeCachedResources( trans2 );
+    assertNull( testInstance.get( meta2 ) );
+    assertEquals( 0, testInstance.resourceCache.size() );
   }
 
   @Test
@@ -250,5 +198,59 @@ public class ExternalResourceCacheTest {
 
     // make sure we're getting a copy, not the original
     assertFalse( resourceValues.getInternal() == resourceValues.getInternal() );
+  }
+
+  @Test
+  public void test_caching_timeout() throws Exception {
+    long timeoutInSeconds = 1;
+    IMetaverseConfig metaverseConfig = mock( IMetaverseConfig.class );
+    when( metaverseConfig.getExternalResourceCacheExpireTime() ).thenReturn( Long.toString( timeoutInSeconds ) );
+    testInstance = new ExternalResourceCache( metaverseConfig );
+
+    initMetas();
+
+    final ExternalResourceCache.ExternalResourceValues resources1 = testInstance
+      .newExternalResourceValues();
+    resources1.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    final ExternalResourceCache.ExternalResourceValues resources2 = testInstance
+      .newExternalResourceValues();
+    resources2.add( Mockito.mock( IExternalResourceInfo.class ) );
+
+    // verify nothing in cache
+    assertNull( testInstance.get( meta1 ) );
+    assertNull( testInstance.get( meta2 ) );
+
+    // add items
+    testInstance.cache( meta1, resources1 );
+    testInstance.cache( meta2, resources2 );
+    assertEquals( resources1, testInstance.get( meta1 ) );
+    assertEquals( resources2, testInstance.get( meta2 ) );
+
+    // sleep to test time eviction policy
+    Thread.sleep( 11 * timeoutInSeconds * 1000 / 10 ); // eviction policy 1.1  * timeout
+
+    // verify
+    assertNull( testInstance.get( meta1 ) );
+    assertNull( testInstance.get( meta2 ) );
+  }
+
+  @Test
+  public void test_GetCacheExpireTime() throws Exception {
+
+    // TEST1 : config null
+    assertEquals( ExternalResourceCache.DEFAULT_TIMEOUT_SECONDS, testInstance.getCacheExpireTime( null ) );
+
+    // TEST2: config expireTime value is null
+    IMetaverseConfig metaverseConfig1 = mock( IMetaverseConfig.class );
+    when( metaverseConfig1.getExternalResourceCacheExpireTime() ).thenReturn( null );
+    assertEquals( ExternalResourceCache.DEFAULT_TIMEOUT_SECONDS, testInstance.getCacheExpireTime( metaverseConfig1 ) );
+
+    // TEST3:
+    long expireTime = 423L;
+    IMetaverseConfig metaverseConfig2 = mock( IMetaverseConfig.class );
+    when( metaverseConfig2.getExternalResourceCacheExpireTime() ).thenReturn( Long.toString( expireTime ) );
+    assertEquals( expireTime, testInstance.getCacheExpireTime( metaverseConfig2 ) );
+
   }
 }

--- a/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/MetaverseConfig.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -33,6 +33,7 @@ public class MetaverseConfig implements IMetaverseConfig {
   private String executionRuntime = "off";
   private String extecutionOutputFolder = "./pentaho-lineage-output";
   private String executionGenerationStrategy = "latest";
+  private String externalResourceCacheExpireTime = "21600";
   private boolean resolveExternalResources = true;
   private boolean deduplicateTransformationFields = true;
   private boolean adjustExternalResourceFields = true;
@@ -132,6 +133,14 @@ public class MetaverseConfig implements IMetaverseConfig {
 
   public boolean getConsolidateSubGraphs() {
     return this.consolidateSubGraphs;
+  }
+
+  public void setExternalResourceCacheExpireTime( final String externalResourceCacheExpireTime ) {
+    this.externalResourceCacheExpireTime = externalResourceCacheExpireTime;
+  }
+
+  public String getExternalResourceCacheExpireTime() {
+    return this.externalResourceCacheExpireTime;
   }
 
   public static boolean consolidateSubGraphs() {

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,7 @@
       <cm:property name="lineage.adjust.external.resource.fields" value="true"/>
       <cm:property name="lineage.generate.subgraphs" value="true"/>
       <cm:property name="lineage.consolidate.subgraphs" value="true"/>
+      <cm:property name="lineage.external.resource.cache.expire.time" value="21600"/>
       <!-- Used for testing ONLY - write delay in seconds -->
       <cm:property name="lineage.delay" value="0"/>
     </cm:default-properties>
@@ -42,6 +43,7 @@
     <property name="adjustExternalResourceFields" value="${lineage.adjust.external.resource.fields}"/>
     <property name="generateSubGraphs" value="${lineage.generate.subgraphs}"/>
     <property name="consolidateSubGraphs" value="${lineage.consolidate.subgraphs}"/>
+    <property name="externalResourceCacheExpireTime" value="${lineage.external.resource.cache.expire.time}"/>
     <!-- Used for testing ONLY - write delay in seconds -->
     <property name="lineageDelay" value="${lineage.delay}"/>
   </bean>

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -95,8 +95,6 @@ public class JobLineageHolderMapTest {
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "transMap", new ConcurrentHashMap() );
-    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "resourceMap", new ConcurrentHashMap() );
     jobLineageHolderMap = JobLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
     jobLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
@@ -158,8 +158,6 @@ public class TransLineageHolderMapTest {
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "transMap", new ConcurrentHashMap() );
-    Whitebox.setInternalState( ExternalResourceCache.getInstance(), "resourceMap", new ConcurrentHashMap() );
     transLineageHolderMap = TransLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
     transLineageHolderMap.setDefaultMetaverseBuilder( defaultBuilder );
@@ -220,42 +218,21 @@ public class TransLineageHolderMapTest {
 
     KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
 
-    Field resourceMapField = ExternalResourceCache.class.getDeclaredField( "resourceMap" );
-    resourceMapField.setAccessible( true );
-    Field transMapField = ExternalResourceCache.class.getDeclaredField( "transMap" );
-    transMapField.setAccessible( true );
-
-    Map<String, ExternalResourceCache.ExternalResourceValues> resourceMap = (Map) resourceMapField.get(
-      ExternalResourceCache.getInstance() );
-    Map<String, ExternalResourceCache.ExternalResourceValues> transMap = (Map) transMapField.get(
-      ExternalResourceCache.getInstance() );
-    assertEquals( 1, resourceMap.size() );
-    assertEquals( 1, transMap.size() );
-
     Field lineageHolderMapField = transLineageHolderMap.getClass().getDeclaredField( "lineageHolderMap" );
     lineageHolderMapField.setAccessible( true );
 
     transLineageHolderMap.removeLineageHolder( trans );
-    // make sure the trans map entry was NOT removed and its resources were NOT removed from the
-    // ExternalResourceCache, since trans has a parent
-    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
-    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
+    // make sure the trans map entry was NOT removed
     Map<Trans, LineageHolder> lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNotNull( lineageHolderMap.get( trans ) );
-    assertEquals( 1, resourceMap.size() ); // the resource map has only one resource
-    assertEquals( 1, transMap.size() );
     assertEquals( 2, lineageHolderMap.size() );
 
     // make sure that removing the parent trans removes it and its sub-transformations from the map and also removed
     // sub-transformation resources from ExternalResourceCache
     transLineageHolderMap.removeLineageHolder( parentTrans );
-    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
-    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNull( lineageHolderMap.get( parentTrans ) );
     assertNull( lineageHolderMap.get( trans ) );
-    assertEquals( 0, resourceMap.size() );
-    assertEquals( 0, transMap.size() );
     assertEquals( 0, lineageHolderMap.size() );
   }
 
@@ -274,43 +251,22 @@ public class TransLineageHolderMapTest {
 
     KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
 
-    Field resourceMapField = ExternalResourceCache.class.getDeclaredField( "resourceMap" );
-    resourceMapField.setAccessible( true );
-    Field transMapField = ExternalResourceCache.class.getDeclaredField( "transMap" );
-    transMapField.setAccessible( true );
-
-    Map<String, Collection<IExternalResourceInfo>> resourceMap = (Map) resourceMapField.get(
-      ExternalResourceCache.getInstance() );
-    Map<String, ExternalResourceCache.ExternalResourceValues> transMap = (Map) transMapField.get(
-      ExternalResourceCache.getInstance() );
-    assertEquals( 1, resourceMap.size() );
-    assertEquals( 1, transMap.size() );
-
     Field lineageHolderMapField = transLineageHolderMap.getClass().getDeclaredField( "lineageHolderMap" );
     lineageHolderMapField.setAccessible( true );
 
     transLineageHolderMap.removeLineageHolder( trans );
-    // make sure the trans map entry was NOT removed and its resources were NOT removed from the
-    // ExternalResourceCache, since trans has a parent
-    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
-    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
+    // make sure the trans map entry was NOT removed
     Map<Trans, LineageHolder> lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNotNull( lineageHolderMap.get( trans ) );
-    assertEquals( 1, resourceMap.size() ); // the resource map has only one resource
-    assertEquals( 1, transMap.size() );
     // lineageHolderMap will only have one member, the parent job will be in the JobLineageHolderMap
     assertEquals( 1, lineageHolderMap.size() );
 
     // make sure that removing the parent trans removes it and its sub-transformations from the map and also removed
     // sub-transformation resources from KettleAnalyzerUtil.resourceMap
     JobLineageHolderMap.getInstance().removeLineageHolder( parentJob );
-    resourceMap = (Map) resourceMapField.get( ExternalResourceCache.getInstance() );
-    transMap = (Map) transMapField.get( ExternalResourceCache.getInstance() );
     lineageHolderMap = (Map) lineageHolderMapField.get( transLineageHolderMap );
     assertNull( lineageHolderMap.get( parentJob ) );
     assertNull( lineageHolderMap.get( trans ) );
-    assertEquals( 0, resourceMap.size() );
-    assertEquals( 0, transMap.size() );
     assertEquals( 0, lineageHolderMap.size() );
   }
 


### PR DESCRIPTION
…bs on the server (9.0 Suite)

 - removed inconsequential transMap variable, TransValues defined
in ExternalResourceCache is not used externally
 - modified caching with eviction by time