### PR TITLE
[BACKLOG-36063] Excel plugin was moved from kettle engine, needs to be

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,6 +186,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>excel-plugins-impl</artifactId>
+      <version>${dependency.pentaho-kettle.kettle-core.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>


### PR DESCRIPTION
pulled in as a separate dependency.