### PR TITLE
[BACKLOG-39574] Unit test fixes for JDK17 upgrade

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,20 +99,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${dependency.org.mockito.mockito-all.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>xerces</artifactId>
-          <groupId>xerces</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${dependency.org.powermock.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.org.mockito.mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,18 +112,6 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${dependency.org.powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${dependency.org.powermock.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>

--- a/api/src/test/java/org/pentaho/dictionary/MetaverseTransientNodeTest.java
+++ b/api/src/test/java/org/pentaho/dictionary/MetaverseTransientNodeTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,8 +31,10 @@ import org.pentaho.metaverse.api.IHasProperties;
 import org.pentaho.metaverse.api.ILogicalIdGenerator;
 import org.pentaho.metaverse.api.MetaverseLogicalIdGenerator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/api/src/test/java/org/pentaho/metaverse/api/MetaverseComponentDescriptorTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/MetaverseComponentDescriptorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,9 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.dictionary.DictionaryConst;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * User: RFellows Date: 8/15/14

--- a/api/src/test/java/org/pentaho/metaverse/api/MetaverseDocumentTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/MetaverseDocumentTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,8 +31,12 @@ import org.pentaho.dictionary.DictionaryConst;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author mburgess

--- a/api/src/test/java/org/pentaho/metaverse/api/MetaverseLinkTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/MetaverseLinkTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,14 +26,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.dictionary.DictionaryConst;
 import org.pentaho.dictionary.MetaverseLink;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class MetaverseLinkTest {
 
   @Mock

--- a/api/src/test/java/org/pentaho/metaverse/api/MetaverseLogicalIdGeneratorTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/MetaverseLogicalIdGeneratorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.dictionary.DictionaryConst;
 
 import java.util.Calendar;
@@ -37,14 +37,16 @@ import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * User: RFellows Date: 9/24/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class MetaverseLogicalIdGeneratorTest {
 
   MetaverseLogicalIdGenerator idGenerator;
@@ -221,6 +223,7 @@ public class MetaverseLogicalIdGeneratorTest {
 
   @Test
   public void testGenerateLogicalId_notAllRequiredPropertiesAvailable() throws Exception {
+    when( node.getProperty( anyString() )).thenReturn( null );
     when( node.getProperty( "name" ) ).thenReturn( "john doe" );
     when( node.getProperty( "age" ) ).thenReturn( 30 );
 

--- a/api/src/test/java/org/pentaho/metaverse/api/PropertiesHolderTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/PropertiesHolderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,9 +32,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class PropertiesHolderTest {
 

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/BaseKettleMetaverseComponentTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/BaseKettleMetaverseComponentTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,13 +31,15 @@ import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.INamespace;
 import org.pentaho.metaverse.api.MetaverseObjectFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BaseKettleMetaverseComponentTest {
 

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/DatabaseConnectionAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/DatabaseConnectionAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -47,15 +47,18 @@ import org.pentaho.metaverse.api.testutils.MetaverseTestUtils;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * This class tests the DatabaseConnectionAnalyzer methods.
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DatabaseConnectionAnalyzerTest {
 
   DatabaseConnectionAnalyzer dbConnectionAnalyzer;

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCacheTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -34,8 +35,6 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.file.BaseFileInputMeta;
 import org.pentaho.metaverse.api.IMetaverseConfig;
 import org.pentaho.metaverse.api.model.IExternalResourceInfo;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Arrays;
@@ -45,12 +44,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class ExternalResourceCacheTest {
 
   @Mock
@@ -89,15 +88,15 @@ public class ExternalResourceCacheTest {
     when( meta2.getParentStepMeta() ).thenReturn(spyMeta2);
     when( transMeta2.getFilename() ).thenReturn( "my_file2" );
 
-    when( trans.getName() ).thenReturn( "my_trans" );
-    when( trans.getFilename() ).thenReturn( "my_file" );
+    lenient().when( trans.getName() ).thenReturn( "my_trans" );
+    lenient().when( trans.getFilename() ).thenReturn( "my_file" );
 
     when( trans.getTransMeta() ).thenReturn( transMeta );
     when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta1} ) );
 
     when( trans2.getTransMeta() ).thenReturn( transMeta2 );
-    when( trans2.getName() ).thenReturn( "my_trans2" );
-    when( trans2.getFilename() ).thenReturn( "my_file2" );
+    lenient().when( trans2.getName() ).thenReturn( "my_trans2" );
+    lenient().when( trans2.getFilename() ).thenReturn( "my_file2" );
     when( transMeta2.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] {spyMeta2} ) );
   }
 

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenJobAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenJobAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
@@ -40,11 +40,11 @@ import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
 import org.pentaho.metaverse.api.Namespace;
 import org.pentaho.metaverse.api.model.BaseMetaverseBuilder;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_FILE;
 
 
-@RunWith ( MockitoJUnitRunner.class )
+@RunWith ( MockitoJUnitRunner.StrictStubs.class )
 public class AnnotationDrivenJobAnalyzerTest {
 
   @Mock AnnotationDrivenStepMetaAnalyzer stepAnalyzer;

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenStepMetaAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenStepMetaAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,37 +25,13 @@ package org.pentaho.metaverse.api.analyzer.kettle.annotations;
 //  is to comment it out completely and revisit a permanent solution in the future. The getTestStepMeta(...) method
 //  is needed for other tests so it is left oncommented along with any associated code.
 //import com.google.common.collect.ImmutableMap;
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Graph;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.pentaho.di.core.KettleClientEnvironment;
-import org.pentaho.di.core.ObjectLocationSpecificationMethod;
-import org.pentaho.di.core.ProgressMonitorListener;
-import org.pentaho.di.core.exception.KettleException;
+
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.injection.InjectionDeep;
-import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaPluginType;
 import org.pentaho.di.core.row.value.ValueMetaString;
-import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
-import org.pentaho.di.repository.Repository;
-import org.pentaho.di.repository.RepositoryDirectory;
-import org.pentaho.di.trans.ISubTransAwareMeta;
 import org.pentaho.di.trans.Trans;
-import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -63,68 +39,15 @@ import org.pentaho.di.trans.step.StepIOMeta;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.di.trans.steps.rowsfromresult.RowsFromResultMeta;
-import org.pentaho.di.trans.steps.writetolog.WriteToLogMeta;
-import org.pentaho.di.trans.streaming.common.BaseStreamStepMeta;
-import org.pentaho.dictionary.DictionaryHelper;
-import org.pentaho.dictionary.MetaverseTransientNode;
-import org.pentaho.metaverse.api.IComponentDescriptor;
-import org.pentaho.metaverse.api.IMetaverseBuilder;
-import org.pentaho.metaverse.api.IMetaverseNode;
-import org.pentaho.metaverse.api.MetaverseAnalyzerException;
-import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
-import org.pentaho.metaverse.api.MetaverseObjectFactory;
-import org.pentaho.metaverse.api.StepField;
-import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
-import org.pentaho.metaverse.api.analyzer.kettle.step.SubtransAnalyzer;
-import org.pentaho.metaverse.api.model.BaseMetaverseBuilder;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import static java.util.Collections.singleton;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.pentaho.dictionary.DictionaryConst.CATEGORY_DATASOURCE;
 import static org.pentaho.dictionary.DictionaryConst.CATEGORY_MESSAGE_QUEUE;
-import static org.pentaho.dictionary.DictionaryConst.CATEGORY_OTHER;
 import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS;
-import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS_CONCEPT;
 import static org.pentaho.dictionary.DictionaryConst.LINK_DEFINES;
-import static org.pentaho.dictionary.DictionaryConst.LINK_DEPENDENCYOF;
-import static org.pentaho.dictionary.DictionaryConst.LINK_INPUTS;
-import static org.pentaho.dictionary.DictionaryConst.LINK_PARENT_CONCEPT;
 import static org.pentaho.dictionary.DictionaryConst.LINK_READBY;
 import static org.pentaho.dictionary.DictionaryConst.LINK_WRITESTO;
-import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_EXTERNAL_CONNECTION;
-import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_TRANS_FIELD;
-import static org.pentaho.dictionary.DictionaryConst.PROPERTY_NAME;
-import static org.pentaho.dictionary.DictionaryConst.PROPERTY_TYPE;
-import static org.pentaho.metaverse.api.analyzer.kettle.annotations.AnnotationDrivenStepMetaAnalyzerTest.TestStepMeta.CONN_TYPE;
-import static org.pentaho.metaverse.api.analyzer.kettle.annotations.AnnotationDrivenStepMetaAnalyzerTest.TestStepMeta.TEST_TYPE;
-import static org.pentaho.metaverse.api.analyzer.kettle.annotations.Metaverse.FALSE;
-import static org.pentaho.metaverse.api.analyzer.kettle.annotations.Metaverse.SUBTRANS_INPUT;
 import static org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceStepAnalyzer.RESOURCE;
 
 

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/ExternalResourceStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
@@ -53,13 +54,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by rfellows on 5/14/15.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class ExternalResourceStepAnalyzerTest {
 
   ExternalResourceStepAnalyzer analyzer;
@@ -121,18 +133,18 @@ public class ExternalResourceStepAnalyzerTest {
   @Test
   public void testAnalyze_input() throws Exception {
     // fake the super.analyze call
-    doReturn( node ).when( (StepAnalyzer<BaseStepMeta>)analyzer ).analyze( descriptor, meta );
+    lenient().doReturn( node ).when( (StepAnalyzer<BaseStepMeta>)analyzer ).analyze( descriptor, meta );
     analyzer.setExternalResourceConsumer( erc );
 
     List<IExternalResourceInfo> resources = new ArrayList<>();
     IExternalResourceInfo resInfo = mock( IExternalResourceInfo.class );
     resources.add( resInfo );
-    when( resInfo.isInput() ).thenReturn( true );
-    when( resInfo.isOutput() ).thenReturn( false );
+    lenient().when( resInfo.isInput() ).thenReturn( true );
+    lenient().when( resInfo.isOutput() ).thenReturn( false );
     when( analyzer.isInput() ).thenReturn( true );
     when( analyzer.isOutput() ).thenReturn( false );
 
-    when( erc.getResourcesFromMeta( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
+    when( erc.getResourcesFromMeta( eq( meta ), any() ) ).thenReturn( resources );
 
     analyzer.customAnalyze( meta, node );
 
@@ -143,19 +155,19 @@ public class ExternalResourceStepAnalyzerTest {
   @Test
   public void testAnalyze_output() throws Exception {
     // fake the super.analyze call
-    doReturn( node ).when( (StepAnalyzer<BaseStepMeta>)analyzer ).analyze( descriptor, meta );
+    lenient().doReturn( node ).when( (StepAnalyzer<BaseStepMeta>)analyzer ).analyze( descriptor, meta );
     analyzer.setExternalResourceConsumer( erc );
 
     List<IExternalResourceInfo> resources = new ArrayList<>();
     IExternalResourceInfo resInfo = mock( IExternalResourceInfo.class );
     resources.add( resInfo );
-    when( resInfo.isInput() ).thenReturn( false );
-    when( resInfo.isOutput() ).thenReturn( true );
+    lenient().when( resInfo.isInput() ).thenReturn( false );
+    lenient().when( resInfo.isOutput() ).thenReturn( true );
 
     when( analyzer.isInput() ).thenReturn( false );
     when( analyzer.isOutput() ).thenReturn( true );
 
-    when( erc.getResourcesFromMeta( eq( meta ), any( IAnalysisContext.class ) ) ).thenReturn( resources );
+    when( erc.getResourcesFromMeta( eq( meta ), any() ) ).thenReturn( resources );
 
     analyzer.customAnalyze( meta, node );
 
@@ -165,7 +177,7 @@ public class ExternalResourceStepAnalyzerTest {
 
   @Test
   public void testGetInputRowMetaInterfaces_isInput() throws Exception {
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    when( parentTransMeta.getPrevStepNames( Mockito.<StepMeta>any() ) ).thenReturn( null );
 
     RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
     doReturn( rowMetaInterface ).when( analyzer ).getOutputFields( meta );
@@ -177,7 +189,7 @@ public class ExternalResourceStepAnalyzerTest {
 
   @Test
   public void testGetInputRowMetaInterfaces_isInputNullOutputFields() throws Exception {
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    when( parentTransMeta.getPrevStepNames( Mockito.<StepMeta>any() ) ).thenReturn( null );
 
     doReturn( null ).when( analyzer ).getOutputFields( meta );
     doReturn( true ).when( analyzer ).isInput();
@@ -198,7 +210,7 @@ public class ExternalResourceStepAnalyzerTest {
     when( inputRmi.getValueMetaList() ).thenReturn( vmis );
     inputs.put( "test", inputRmi );
     doReturn( inputs ).when( analyzer ).getInputFields( meta );
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    lenient().when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
 
     RowMetaInterface rowMetaInterface = new RowMeta();
     rowMetaInterface.addValueMeta( vmi );
@@ -274,7 +286,7 @@ public class ExternalResourceStepAnalyzerTest {
     IAnalysisContext context = mock( IAnalysisContext.class );
     doReturn( "thisStepName" ).when( analyzer ).getStepName();
     analyzer.rootNode = node;
-    when( node.getLogicalId() ).thenReturn( "logical id" );
+    lenient().when( node.getLogicalId() ).thenReturn( "logical id" );
     ValueMetaInterface vmi = new ValueMeta( "name", 1 );
 
     IMetaverseNode inputFieldNode = analyzer.createInputFieldNode(
@@ -297,7 +309,7 @@ public class ExternalResourceStepAnalyzerTest {
   @Test
   public void testCreateOutputFieldNode_resource() throws Exception {
     IAnalysisContext context = mock( IAnalysisContext.class );
-    doReturn( "thisStepName" ).when( analyzer ).getStepName();
+    lenient().doReturn( "thisStepName" ).when( analyzer ).getStepName();
     analyzer.rootNode = node;
     when( node.getLogicalId() ).thenReturn( "logical id" );
     ValueMetaInterface vmi = new ValueMeta( "name", 1 );
@@ -323,7 +335,7 @@ public class ExternalResourceStepAnalyzerTest {
   @Test
   public void testCreateOutputFieldNode() throws Exception {
     IAnalysisContext context = mock( IAnalysisContext.class );
-    doReturn( "thisStepName" ).when( analyzer ).getStepName();
+    lenient().doReturn( "thisStepName" ).when( analyzer ).getStepName();
     analyzer.rootNode = node;
     when( node.getLogicalId() ).thenReturn( "logical id" );
     ValueMetaInterface vmi = new ValueMeta( "name", 1 );
@@ -369,8 +381,8 @@ public class ExternalResourceStepAnalyzerTest {
     when( inputNode.getType() ).thenReturn( "A" );
     when( outputNode.getType() ).thenReturn( "B" );
 
-    doReturn( true ).when( analyzer ).isInput();
-    doReturn( false ).when( analyzer ).isOutput();
+    lenient().doReturn( true ).when( analyzer ).isInput();
+    lenient().doReturn( false ).when( analyzer ).isOutput();
 
     analyzer.linkChangeNodes( inputNode, outputNode );
     verify( builder ).addLink( inputNode, DictionaryConst.LINK_POPULATES, outputNode );
@@ -385,8 +397,8 @@ public class ExternalResourceStepAnalyzerTest {
     when( inputNode.getType() ).thenReturn( "A" );
     when( outputNode.getType() ).thenReturn( "A" );
 
-    doReturn( true ).when( analyzer ).isInput();
-    doReturn( false ).when( analyzer ).isOutput();
+    lenient().doReturn( true ).when( analyzer ).isInput();
+    lenient().doReturn( false ).when( analyzer ).isOutput();
 
     analyzer.linkChangeNodes( inputNode, outputNode );
     verify( builder, never() ).addLink( inputNode, DictionaryConst.LINK_POPULATES, outputNode );
@@ -396,7 +408,7 @@ public class ExternalResourceStepAnalyzerTest {
   @Test
   public void testGetInputFieldsToIgnore() {
 
-    doReturn( true ).when( analyzer ).isInput();
+    lenient().doReturn( true ).when( analyzer ).isInput();
 
     // setup input fields
     RowMetaInterface inputFieldRowMeta = mock( RowMetaInterface.class );

--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/step/StepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -56,16 +56,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by rfellows on 5/14/15.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StepAnalyzerTest {
 
   StepAnalyzer analyzer;
@@ -548,7 +561,7 @@ public class StepAnalyzerTest {
 
   @Test
   public void testCreateOutputFieldNode() throws Exception {
-    doReturn( "thisStepName" ).when( analyzer ).getStepName();
+    lenient().doReturn( "thisStepName" ).when( analyzer ).getStepName();
 
     MetaverseTransientNode node = new MetaverseTransientNode( "node id" );
     doReturn( node ).when( analyzer ).createNodeFromDescriptor( any( IComponentDescriptor.class ) );
@@ -571,7 +584,7 @@ public class StepAnalyzerTest {
 
   @Test
   public void testProcessInputs_noPrevSteps() throws Exception {
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    lenient().when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
     StepNodes stepNodes = analyzer.processInputs( baseStepMeta );
     assertNotNull( stepNodes );
     assertEquals( 0, stepNodes.getStepNames().size() );
@@ -581,7 +594,7 @@ public class StepAnalyzerTest {
   @Test
   public void testProcessInputs() throws Exception {
     String[] prevStepNames = new String[]{ "prevStep", "prevStep2" };
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( prevStepNames );
+    lenient().when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( prevStepNames );
 
     Map<String, RowMetaInterface> inputRmis = new HashMap<>();
     RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
@@ -768,9 +781,9 @@ public class StepAnalyzerTest {
 
   @Test
   public void testLoadInputAndOutputStreamFieldsWithException() throws KettleStepException {
-    when( analyzer.parentTransMeta.getPrevStepFields( eq( analyzer.parentStepMeta ),
+    lenient().when( analyzer.parentTransMeta.getPrevStepFields( eq( analyzer.parentStepMeta ),
       any( ProgressMonitorListener.class ) ) ).thenThrow( KettleStepException.class );
-    when( analyzer.parentTransMeta.getStepFields( eq( analyzer.parentStepMeta ),
+    lenient().when( analyzer.parentTransMeta.getStepFields( eq( analyzer.parentStepMeta ),
       any( ProgressMonitorListener.class ) ) ).thenThrow( KettleStepException.class );
     analyzer.loadInputAndOutputStreamFields( baseStepMeta );
     assertEquals( 0, analyzer.prevFields.size() );
@@ -784,7 +797,7 @@ public class StepAnalyzerTest {
 
   @Test
   public void testGetStepFieldOriginDescriptor() throws Exception {
-    when( mockStepFields.getFieldNames() ).thenReturn( new String[]{ "field1", "field2" } );
+    lenient().when( mockStepFields.getFieldNames() ).thenReturn( new String[]{ "field1", "field2" } );
     analyzer.stepFields = mockStepFields;
     IMetaverseNode rootNode = mock( IMetaverseNode.class );
     when( rootNode.getProperty( DictionaryConst.PROPERTY_NAMESPACE ) ).thenReturn( "{}" );

--- a/api/src/test/java/org/pentaho/metaverse/api/model/LineageHolderTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/model/LineageHolderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,17 +26,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
 
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class LineageHolderTest {
 
   LineageHolder lineageHolder;

--- a/api/src/test/java/org/pentaho/metaverse/api/model/kettle/FieldInfoTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/model/kettle/FieldInfoTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.ValueMetaInterface;
 
 import static org.junit.Assert.assertEquals;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 /**
  * User: RFellows Date: 12/3/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class FieldInfoTest {
 
   FieldInfo fieldInfo;

--- a/api/src/test/java/org/pentaho/metaverse/api/model/kettle/HopInfoTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/model/kettle/HopInfoTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,17 +26,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.step.StepMeta;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
  * User: RFellows Date: 12/3/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class HopInfoTest {
 
   HopInfo hopInfo;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -219,33 +219,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${dependency.org.mockito.mockito-all.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${dependency.org.powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${dependency.org.powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${dependency.org.powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
-      <version>${dependency.org.powermock.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.org.mockito.mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- TODO: uncomment once https://jira.pentaho.com/browse/ENGOPS-4612 is resolved -->

--- a/core/src/main/java/org/pentaho/metaverse/impl/model/ExecutionProfileUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/model/ExecutionProfileUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.metaverse.impl.model;
 
+import com.cronutils.utils.VisibleForTesting;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -43,7 +44,12 @@ public class ExecutionProfileUtil {
 
   public static void outputExecutionProfile( OutputStream outputStream, IExecutionProfile executionProfile )
     throws IOException {
+    outputExecutionProfile( outputStream, executionProfile, new ObjectMapper() );
+  }
 
+  @VisibleForTesting
+  protected static void outputExecutionProfile( OutputStream outputStream, IExecutionProfile executionProfile, ObjectMapper mapper )
+    throws IOException {
     PrintStream out = null;
     try {
       if ( outputStream instanceof PrintStream ) {
@@ -51,7 +57,6 @@ public class ExecutionProfileUtil {
       } else {
         out = new PrintStream( outputStream );
       }
-      ObjectMapper mapper = new ObjectMapper();
       mapper.enable( SerializationFeature.INDENT_OUTPUT );
       mapper.disable( SerializationFeature.FAIL_ON_EMPTY_BEANS );
       mapper.enable( SerializationFeature.WRAP_EXCEPTIONS );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/JobAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/JobAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.parameters.UnknownParamException;
@@ -57,9 +57,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,7 +71,7 @@ import static org.mockito.Mockito.when;
  * @See com.pentaho.analyzer.kettle.MetaverseDocumentAnalyzerTest for base JobAnalyzer tests. Tests here
  * are specific to the JobAnalyzer.
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobAnalyzerTest {
 
   private JobAnalyzer analyzer;
@@ -130,9 +134,9 @@ public class JobAnalyzerTest {
 
     analyzer = new JobAnalyzer();
     analyzer.setMetaverseBuilder( mockBuilder );
-    when( namespace.getParentNamespace() ).thenReturn( namespace );
+    lenient().when( namespace.getParentNamespace() ).thenReturn( namespace );
 
-    when( mockJobDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_JOB );
+    lenient().when( mockJobDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_JOB );
     when( mockJobDoc.getContent() ).thenReturn( mockContent );
     when( mockJobDoc.getNamespace() ).thenReturn( namespace );
 
@@ -144,7 +148,7 @@ public class JobAnalyzerTest {
 
     when( mockJob.getJobMeta() ).thenReturn( mockContent );
 
-    when( mockContent.listVariables() ).thenReturn( new String[] { } );
+    lenient().when( mockContent.listVariables() ).thenReturn( new String[] { } );
     final String PARAM = "param1";
     when( mockContent.listParameters() ).thenReturn( new String[] { PARAM } );
     when( mockContent.getParameterDefault( PARAM ) ).thenReturn( "default" );
@@ -172,7 +176,7 @@ public class JobAnalyzerTest {
 
     JobEntryCopy mockToEntryMeta = mock( JobEntryCopy.class );
     when( mockToEntryMeta.getEntry() ).thenReturn( mockJobEntryInterface );
-    when( mockToEntryMeta.getParentJobMeta() ).thenReturn( mockContent );
+    lenient().when( mockToEntryMeta.getParentJobMeta() ).thenReturn( mockContent );
 
     when( mockContent.nrJobEntries() ).thenReturn( 2 );
     when( mockContent.getJobEntry( 0 ) ).thenReturn( mockJobEntry );
@@ -229,7 +233,7 @@ public class JobAnalyzerTest {
   @Test( expected = MetaverseAnalyzerException.class )
   public void testAnalyzeWithBadXML() throws MetaverseAnalyzerException {
     IDocument newMockJobDoc = mock( IDocument.class );
-    when( newMockJobDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_JOB );
+    lenient().when( newMockJobDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_JOB );
     when( newMockJobDoc.getContent() ).thenReturn(
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
             "<job>This is not a valid JobMeta doc!" );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/TransformationAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/TransformationAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.parameters.UnknownParamException;
@@ -57,15 +57,21 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @See com.pentaho.analyzer.kettle.MetaverseDocumentAnalyzerTest for base TransformationAnalyzer tests. Tests here
  * are specific to the TransformationAnalyzer.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransformationAnalyzerTest {
 
   private TransformationAnalyzer analyzer;
@@ -127,9 +133,8 @@ public class TransformationAnalyzerTest {
 
     analyzer = new TransformationAnalyzer();
     analyzer.setMetaverseBuilder( mockBuilder );
-    when( namespace.getParentNamespace() ).thenReturn( namespace );
+    lenient().when( namespace.getParentNamespace() ).thenReturn( namespace );
 
-    when( mockTransDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_TRANS );
     when( mockTransDoc.getContent() ).thenReturn( mockContent );
     when( mockTransDoc.getNamespace() ).thenReturn( namespace );
 
@@ -214,7 +219,6 @@ public class TransformationAnalyzerTest {
   @Test( expected = MetaverseAnalyzerException.class )
   public void testAnalyzeWithBadXML() throws MetaverseAnalyzerException {
     IDocument newMockTransDoc = mock( IDocument.class );
-    when( newMockTransDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_TRANS );
     when( newMockTransDoc.getContent() ).thenReturn(
       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
         "<transformation>This is not a valid TransMeta doc!" );
@@ -224,7 +228,6 @@ public class TransformationAnalyzerTest {
   @Test( expected = MetaverseAnalyzerException.class )
   public void testAnalyzeWithMissingPlugin() throws MetaverseAnalyzerException {
     IDocument newMockTransDoc = mock( IDocument.class );
-    when( newMockTransDoc.getType() ).thenReturn( DictionaryConst.NODE_TYPE_TRANS );
     when( newMockTransDoc.getContent() ).thenReturn(
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><transformation><step><name>Load text from file</name>"
         + "<type>LoadTextFromFile</type></step></transformation>" );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/BaseRuntimeExtensionPointTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/BaseRuntimeExtensionPointTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,7 +22,6 @@
 
 package org.pentaho.metaverse.analyzer.kettle.extensionpoints;
 
-import com.tinkerpop.blueprints.Graph;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -48,15 +47,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BaseRuntimeExtensionPointTest {
 
@@ -117,7 +116,7 @@ public class BaseRuntimeExtensionPointTest {
     assertNotEquals( 0, baos.size() );
     assertTrue( baos.toString().contains( "testName" ) );
 
-    verify( graphWriter, times( 1 ) ).outputGraph( any( Graph.class ), any( OutputStream.class ) );
+    verify( graphWriter, times( 1 ) ).outputGraph( any(), any( OutputStream.class ) );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/job/JobLineageHolderMapTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.Trans;
@@ -37,7 +37,7 @@ import org.pentaho.metaverse.analyzer.kettle.extensionpoints.trans.TransLineageH
 import org.pentaho.metaverse.api.IMetaverseBuilder;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
 import org.pentaho.metaverse.api.model.LineageHolder;
-import org.powermock.reflect.Whitebox;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for JobLineageHolderMap
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobLineageHolderMapTest {
 
   JobLineageHolderMap jobLineageHolderMap;
@@ -89,16 +90,15 @@ public class JobLineageHolderMapTest {
   private JobMeta jobMeta;
 
   private void initMetas() {
-
-    when( job.getJobMeta() ).thenReturn( jobMeta );
-    when( parentTrans.getTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( job.getJobMeta() ).thenReturn( jobMeta );
+    lenient().when( parentTrans.getTransMeta() ).thenReturn( parentTransMeta );
   }
 
   @Before
   public void setUp() throws Exception {
-    Whitebox.setInternalState( JobLineageHolderMap.getInstance(), "lineageHolderMap",
+    ReflectionTestUtils.setField( JobLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
+    ReflectionTestUtils.setField( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     jobLineageHolderMap = JobLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
@@ -107,7 +107,7 @@ public class JobLineageHolderMapTest {
 
   @After
   public void cleanUp() throws Exception {
-    Whitebox.setInternalState( jobLineageHolderMap, "lineageHolderMap",
+    ReflectionTestUtils.setField( jobLineageHolderMap, "lineageHolderMap",
       Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
   }
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtilTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransExtensionPointUtilTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.metaverse.api.IDocumentController;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransExtensionPointUtilTest {
 
   @Mock

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/extensionpoints/trans/TransLineageHolderMapTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.trans.Trans;
@@ -42,7 +42,7 @@ import org.pentaho.metaverse.api.IMetaverseBuilder;
 import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
 import org.pentaho.metaverse.api.model.IExecutionProfile;
 import org.pentaho.metaverse.api.model.LineageHolder;
-import org.powermock.reflect.Whitebox;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -62,7 +63,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for TransLineageHolderMap
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransLineageHolderMapTest {
 
   TransLineageHolderMap transLineageHolderMap;
@@ -121,45 +122,44 @@ public class TransLineageHolderMapTest {
   private StepMeta spyMeta2;
 
   private void initMetas() {
+    lenient().when( trans.getTransMeta() ).thenReturn( transMeta );
+    lenient().when( trans.getName() ).thenReturn( "trans" );
+    lenient().when( trans.getFilename() ).thenReturn( "trans.ktr" );
+    lenient().when( parentTrans.getTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( parentTrans.getName() ).thenReturn( "parentTrans" );
+    lenient().when( parentTrans.getFilename() ).thenReturn( "parentTrans.ktr" );
 
-    when( trans.getTransMeta() ).thenReturn( transMeta );
-    when( trans.getName() ).thenReturn( "trans" );
-    when( trans.getFilename() ).thenReturn( "trans.ktr" );
-    when( parentTrans.getTransMeta() ).thenReturn( parentTransMeta );
-    when( parentTrans.getName() ).thenReturn( "parentTrans" );
-    when( parentTrans.getFilename() ).thenReturn( "parentTrans.ktr" );
+    lenient().when( parentJob.getJobname() ).thenReturn( "parentJob" );
+    lenient().when( parentJob.getFilename() ).thenReturn( "parentJob.kjb" );
 
-    when( parentJob.getJobname() ).thenReturn( "parentJob" );
-    when( parentJob.getFilename() ).thenReturn( "parentJob.kjb" );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
 
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
-
-    when( transMeta.getFilename() ).thenReturn( "my_file" );
+    lenient().when( transMeta.getFilename() ).thenReturn( "my_file" );
 
     spyMeta = spy( new StepMeta( "test", meta ) );
-    when( meta.getParentStepMeta() ).thenReturn( spyMeta );
-    when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta.writesToFile() ).thenReturn( true );
-    when( meta.getFilePaths( false) ).thenReturn( filePaths );
+    lenient().when( meta.getParentStepMeta() ).thenReturn( spyMeta );
+    lenient().when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
+    lenient().when( meta.writesToFile() ).thenReturn( true );
+    lenient().when( meta.getFilePaths( false) ).thenReturn( filePaths );
 
     spyMeta2 = spy( new StepMeta( "test2", meta2 ) );
-    when( meta2.getParentStepMeta() ).thenReturn( spyMeta2 );
-    when( spyMeta2.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta2.writesToFile() ).thenReturn( true );
-    when( meta2.getFilePaths( false) ).thenReturn( filePaths2 );
+    lenient().when( meta2.getParentStepMeta() ).thenReturn( spyMeta2 );
+    lenient().when( spyMeta2.getParentTransMeta() ).thenReturn( transMeta );
+    lenient().when( meta2.writesToFile() ).thenReturn( true );
+    lenient().when( meta2.getFilePaths( false) ).thenReturn( filePaths2 );
 
-    when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta, spyMeta2 } ) );
+    lenient().when( transMeta.getSteps() ).thenReturn( Arrays.asList( new StepMeta[] { spyMeta, spyMeta2 } ) );
 
-    when( input.getStepMetaInterface() ).thenReturn( meta );
-    when( input.getStepMeta() ).thenReturn( spyMeta );
-    when( input.getTrans() ).thenReturn( trans );
+    lenient().when( input.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( input.getStepMeta() ).thenReturn( spyMeta );
+    lenient().when( input.getTrans() ).thenReturn( trans );
   }
 
   @Before
   public void setUp() throws Exception {
-    Whitebox.setInternalState( JobLineageHolderMap.getInstance(), "lineageHolderMap",
-            Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
-    Whitebox.setInternalState( TransLineageHolderMap.getInstance(), "lineageHolderMap",
+    ReflectionTestUtils.setField( JobLineageHolderMap.getInstance(), "lineageHolderMap",
+      Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
+    ReflectionTestUtils.setField( TransLineageHolderMap.getInstance(), "lineageHolderMap",
             Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
     transLineageHolderMap = TransLineageHolderMap.getInstance();
     mockHolder = spy( new LineageHolder() );
@@ -168,7 +168,7 @@ public class TransLineageHolderMapTest {
 
   @After
   public void cleanUp() throws Exception {
-    Whitebox.setInternalState( transLineageHolderMap, "lineageHolderMap",
+    ReflectionTestUtils.setField( transLineageHolderMap, "lineageHolderMap",
       Collections.synchronizedMap( new MapMaker().weakKeys().makeMap() ) );
   }
 
@@ -209,7 +209,6 @@ public class TransLineageHolderMapTest {
   @Test
   public void testRemoveLineageHolderWithParentTrans() throws Exception {
     initMetas();
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
 
     // initialize the lineage holder for this transformation
     transLineageHolderMap.getLineageHolder( trans );
@@ -217,7 +216,7 @@ public class TransLineageHolderMapTest {
     // test with parent transformation being set
     when( trans.getParentTrans() ).thenReturn( parentTrans );
 
-    when( input.environmentSubstitute( Mockito.any( String.class ) ) ).thenReturn( "/path/to/row/file" );
+    when( input.environmentSubstitute( Mockito.<String>any() ) ).thenReturn( "/path/to/row/file" );
 
     KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
 
@@ -242,7 +241,6 @@ public class TransLineageHolderMapTest {
   @Test
   public void testRemoveLineageHolderWithParentJob() throws Exception {
     initMetas();
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
 
     // initialize the lineage holder for this transformation
     transLineageHolderMap.getLineageHolder( trans );
@@ -250,7 +248,7 @@ public class TransLineageHolderMapTest {
     // test with parent transformation being set
     when( trans.getParentJob() ).thenReturn( parentJob );
 
-    when( input.environmentSubstitute( Mockito.any( String.class ) ) ).thenReturn( "/path/to/row/file" );
+    when( input.environmentSubstitute( Mockito.<String>any() ) ).thenReturn( "/path/to/row/file" );
 
     KettleAnalyzerUtil.getResourcesFromRow( input, rowMetaInterface, new String[] { "id", "name" } );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/GenericJobEntryMetaAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/GenericJobEntryMetaAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryInterface;
@@ -41,10 +41,10 @@ import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class GenericJobEntryMetaAnalyzerTest {
 
   private GenericJobEntryMetaAnalyzer analyzer = new GenericJobEntryMetaAnalyzer();
@@ -74,7 +74,6 @@ public class GenericJobEntryMetaAnalyzerTest {
     when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( objectFactory );
     when( objectFactory.createNodeObject( anyString(), anyString(),
         anyString() ) ).thenReturn( new MetaverseTransientNode( "name" ) );
-    when( mockJobEntry.getName() ).thenReturn( "job entry" );
     when( mockJobEntry.getParentJob() ).thenReturn( mockParentJob );
     when( mockParentJob.getJobMeta() ).thenReturn( mockParentJobMeta );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/JobEntryAnalyzerProviderTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/JobEntryAnalyzerProviderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,22 +29,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryAnalyzer;
-import org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzer;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobEntryAnalyzerProviderTest {
 
   JobEntryAnalyzerProvider provider;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/job/JobJobEntryAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/job/JobJobEntryAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,18 +27,17 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
-import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.job.JobEntryJob;
 import org.pentaho.di.job.entry.JobEntryInterface;
-import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.dictionary.DictionaryConst;
@@ -56,16 +55,21 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for JobJobEntryAnalyzer
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobJobEntryAnalyzerTest {
 
   private static final String TEST_FILE_NAME = "file.kjb";
@@ -108,15 +112,14 @@ public class JobJobEntryAnalyzerTest {
   @Before
   public void setUp() throws Exception {
     when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( objectFactory );
-    when( objectFactory.createNodeObject( anyString(), anyString(),
+    when( objectFactory.createNodeObject( Mockito.<String>any(), any(),
       anyString() ) ).thenReturn( new MetaverseTransientNode( "name" ) );
-    when( jobEntryJob.getName() ).thenReturn( "job entry" );
     when( jobEntryJob.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.FILENAME );
     when( jobEntryJob.getFilename() ).thenReturn( TEST_FILE_NAME );
     when( jobEntryJob.getParentJob() ).thenReturn( mockParentJob );
     when( mockParentJob.getJobMeta() ).thenReturn( mockParentJobMeta );
     when( namespace.getParentNamespace() ).thenReturn( namespace );
-    when( mockParentJobMeta.environmentSubstitute( anyString() ) ).thenAnswer( new Answer<String>() {
+    when( mockParentJobMeta.environmentSubstitute( Mockito.<String>any() ) ).thenAnswer( new Answer<String>() {
       @Override
       public String answer( InvocationOnMock invocation ) throws Throwable {
         return (String) invocation.getArguments()[0];
@@ -189,7 +192,7 @@ public class JobJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryJob.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
     // Test exception
-    when( repo.findDirectory( anyString() ) ).thenThrow( new KettleException() );
+    when( repo.findDirectory( Mockito.<String>any() ) ).thenThrow( new KettleException() );
     spyAnalyzer.analyze( descriptor, jobEntryJob );
   }
 
@@ -207,9 +210,8 @@ public class JobJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryJob.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
     // Test exception
-    when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
-    when( repo.loadJob( anyString(), eq( repoDir ), any( ProgressMonitorListener.class ), anyString() ) )
-      .thenReturn( childJobMeta );
+    when( repo.findDirectory( Mockito.<String>any() ) ).thenReturn( repoDir );
+    when( repo.loadJob( any(), eq( repoDir ), any(), any() ) ).thenReturn( childJobMeta );
     spyAnalyzer.analyze( descriptor, jobEntryJob );
   }
 
@@ -219,7 +221,7 @@ public class JobJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryJob.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
     // Test exception
-    when( repo.loadJob( any( ObjectId.class ), anyString() ) ).thenThrow( new KettleException() );
+    when( repo.loadJob( any(), any() ) ).thenThrow( new KettleException() );
     spyAnalyzer.analyze( descriptor, jobEntryJob );
   }
 
@@ -236,7 +238,7 @@ public class JobJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryJob.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
     // Test exception
-    when( repo.loadJob( any( ObjectId.class ), anyString() ) ).thenReturn( childJobMeta );
+    when( repo.loadJob( any(), any() ) ).thenReturn( childJobMeta );
     spyAnalyzer.analyze( descriptor, jobEntryJob );
   }
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/transjob/TransJobEntryAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/jobentry/transjob/TransJobEntryAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,18 +27,17 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
-import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryInterface;
-import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.TransMeta;
@@ -57,11 +56,19 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransJobEntryAnalyzerTest {
 
   private static final String TEST_FILE_NAME = "file.ktr";
@@ -104,16 +111,14 @@ public class TransJobEntryAnalyzerTest {
   @Before
   public void setUp() throws Exception {
     when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( objectFactory );
-    when( objectFactory.createNodeObject( anyString(), anyString(),
-      anyString() ) ).thenReturn( new MetaverseTransientNode( "name" ) );
-    when( jobEntryTrans.getName() ).thenReturn( "job entry" );
+    when( objectFactory.createNodeObject( Mockito.<String>any(), any(), any() ) ).thenReturn( new MetaverseTransientNode( "name" ) );
     when( jobEntryTrans.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.FILENAME );
     when( jobEntryTrans.getFilename() ).thenReturn( TEST_FILE_NAME );
     when( jobEntryTrans.getParentJob() ).thenReturn( mockParentJob );
     when( mockParentJob.getJobMeta() ).thenReturn( mockParentJobMeta );
     when( namespace.getParentNamespace() ).thenReturn( namespace );
 
-    when( mockParentJobMeta.environmentSubstitute( anyString() ) ).thenAnswer( new Answer<String>() {
+    when( mockParentJobMeta.environmentSubstitute( Mockito.<String>any() ) ).thenAnswer( new Answer<String>() {
       @Override
       public String answer( InvocationOnMock invocation ) throws Throwable {
         return (String) invocation.getArguments()[0];
@@ -186,7 +191,7 @@ public class TransJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryTrans.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
     // Test exception
-    when( repo.findDirectory( anyString() ) ).thenThrow( new KettleException() );
+    when( repo.findDirectory( Mockito.<String>any() ) ).thenThrow( new KettleException() );
     spyAnalyzer.analyze( descriptor, jobEntryTrans );
   }
 
@@ -203,9 +208,8 @@ public class TransJobEntryAnalyzerTest {
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryTrans.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
-    when( repo.loadTransformation( anyString(), eq( repoDir ), any( ProgressMonitorListener.class ), anyBoolean(), anyString() ) )
-      .thenReturn( childTransMeta );
+    when( repo.findDirectory( Mockito.<String>any() ) ).thenReturn( repoDir );
+    when( repo.loadTransformation( any(), eq( repoDir ), any(), anyBoolean(), any() ) ).thenReturn( childTransMeta );
     spyAnalyzer.analyze( descriptor, jobEntryTrans );
   }
 
@@ -215,7 +219,7 @@ public class TransJobEntryAnalyzerTest {
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryTrans.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
     // Test exception
-    when( repo.loadTransformation( any( ObjectId.class ), anyString() ) ).thenThrow( new KettleException() );
+    when( repo.loadTransformation( any(), any() ) ).thenThrow( new KettleException() );
     spyAnalyzer.analyze( descriptor, jobEntryTrans );
   }
 
@@ -231,7 +235,7 @@ public class TransJobEntryAnalyzerTest {
     Repository repo = mock( Repository.class );
     when( mockParentJobMeta.getRepository() ).thenReturn( repo );
     when( jobEntryTrans.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
-    when( repo.loadTransformation( any( ObjectId.class ), anyString() ) ).thenReturn( childTransMeta );
+    when( repo.loadTransformation( any(), any() ) ).thenReturn( childTransMeta );
     when( childTransMeta.getPathAndName() ).thenReturn( "/path/to/test" );
     when( childTransMeta.getDefaultExtension() ).thenReturn( "ktr" );
     spyAnalyzer.analyze( descriptor, jobEntryTrans );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/GenericStepMetaAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/GenericStepMetaAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.metaverse.api.IMetaverseNode;
 
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertNull;
 /**
  * @author mburgess
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class)
 public class GenericStepMetaAnalyzerTest {
 
   GenericStepMetaAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/StepAnalyzerProviderTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/StepAnalyzerProviderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.tableoutput.TableOutputMeta;
 import org.pentaho.metaverse.analyzer.kettle.step.tableoutput.TableOutputStepAnalyzer;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StepAnalyzerProviderTest {
 
   StepAnalyzerProvider provider;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/calculator/CalculatorStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/calculator/CalculatorStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.calculator.CalculatorMeta;
 import org.pentaho.di.trans.steps.calculator.CalculatorMetaFunction;
@@ -40,11 +40,13 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class CalculatorStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private CalculatorStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputExternalResourceConsumerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputExternalResourceConsumerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,8 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.TransMeta;
@@ -38,11 +37,13 @@ import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 
 import java.util.Collection;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class CsvFileInputExternalResourceConsumerTest {
 
   @Mock CsvInputMeta meta;
@@ -66,8 +67,6 @@ public class CsvFileInputExternalResourceConsumerTest {
     assertFalse( resources.isEmpty() );
     assertEquals( 2, resources.size() );
 
-    when( rmi.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
     resources = consumer.getResourcesFromRow( input, rmi, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/csvfileinput/CsvFileInputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.csvinput.CsvInputMeta;
 import org.pentaho.dictionary.DictionaryConst;
@@ -42,10 +42,16 @@ import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class CsvFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private CsvFileInputStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fileinput/text/TextFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fileinput/text/TextFileInputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
@@ -49,11 +49,16 @@ import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private TextFileInputStepAnalyzer analyzer;
@@ -82,21 +87,21 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
     mockFactory = MetaverseTestUtils.getMetaverseObjectFactory();
     when( mockBuilder.getMetaverseObjectFactory() ).thenReturn( mockFactory );
-    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
+    lenient().when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
 
     analyzer = new TextFileInputStepAnalyzer();
     analyzer.setMetaverseBuilder( mockBuilder );
 
-    when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
-    when( mockTextFileInput.getStepMeta() ).thenReturn( mockStepMeta );
-    when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( mockTextFileInput.getStepMeta() ).thenReturn( mockStepMeta );
+    lenient().when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
   }
 
   @Test
   public void testGetUsedFields_fileNameFromField() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( true );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 1, usedFields.size() );
@@ -107,9 +112,9 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   @Test
   public void testGetUsedFields_isNotAcceptingFilenames() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( false );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( false );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 0, usedFields.size() );
@@ -117,9 +122,9 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   @Test
   public void testGetUsedFields_isAcceptingFilenamesButNoStepName() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( null );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( true );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( null );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 0, usedFields.size() );
@@ -162,7 +167,6 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
     when( meta.getParentStepMeta() ).thenReturn( spyMeta );
     when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta.getFileName() ).thenReturn( null );
     when( meta.writesToFile() ).thenReturn( true );
     String[] filePaths = { "/path/to/file1", "/another/path/to/file2" };
     when( meta.getFilePaths( false) ).thenReturn( filePaths );
@@ -182,7 +186,7 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     // call to getResourcesFromMeta does not cache resources, only calls to getResourcesFromRow do
     assertTrue( resources.isEmpty() );
 
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
       .thenReturn( "/path/to/row/file" );
     when( mockTextFileInput.environmentSubstitute( "/path/to/row/file" ) ).thenReturn( "/path/to/row/file" );
     when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
@@ -190,8 +194,7 @@ public class TextFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    when( mockRowMetaInterface.getString( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenThrow( KettleValueException.class );
     resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     // even when the call to getString throws an exception, we can still get resources from the cache
     assertFalse( resources.isEmpty() );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/filterrows/FilterRowsStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/filterrows/FilterRowsStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.filterrows.FilterRowsMeta;
@@ -40,10 +40,17 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class FilterRowsStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private FilterRowsStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fixedfileinput/FixedFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/fixedfileinput/FixedFileInputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -47,11 +47,16 @@ import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class FixedFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private FixedFileInputStepAnalyzer analyzer;
@@ -66,7 +71,6 @@ public class FixedFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   @Before
   public void setUp() throws Exception {
-    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
     descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_TRANS_STEP, mockNamespace );
     analyzer = spy( new FixedFileInputStepAnalyzer() );
     analyzer.setDescriptor( descriptor );
@@ -120,8 +124,8 @@ public class FixedFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     assertFalse( consumer.isDataDriven( meta ) );
     assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
 
-    when( rmi.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    lenient().when( rmi.getString( Mockito.any(), Mockito.any(), Mockito.any() ) )
+      .thenThrow( KettleValueException.class );
     Collection<IExternalResourceInfo> resources = consumer.getResourcesFromRow( input, rmi, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 
@@ -141,8 +145,8 @@ public class FixedFileInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
     assertFalse( consumer.isDataDriven( meta ) );
     assertFalse( consumer.getResourcesFromMeta( meta ).isEmpty() );
 
-    when( rmi.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    lenient().when( rmi.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
+      .thenThrow( KettleValueException.class );
     Collection<IExternalResourceInfo> resources = consumer.getResourcesFromRow( input, rmi, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/groupby/GroupByStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/groupby/GroupByStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.groupby.GroupByMeta;
@@ -35,16 +35,23 @@ import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IClonableStepAnalyzer;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class GroupByStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private GroupByStepAnalyzer analyzer;
@@ -92,11 +99,11 @@ public class GroupByStepAnalyzerTest extends ClonableStepAnalyzerTest {
     fields.add( new StepField( "prev", "donation" ) );
     fields.add( new StepField( "prev", "state" ) );
     fields.add( new StepField( "prev", "country" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     int expectedUsedFieldCount = mockAggregateFields.length + mockSubjectFields.length;
     assertEquals( expectedUsedFieldCount, usedFields.size() );
-    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any( StepNodes.class ) );
+    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/httpclient/HTTPClientStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/httpclient/HTTPClientStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -53,13 +53,23 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class HTTPClientStepAnalyzerTest extends ClonableStepAnalyzerTest
 {
 
@@ -84,9 +94,8 @@ public class HTTPClientStepAnalyzerTest extends ClonableStepAnalyzerTest
     analyzer.setDescriptor( descriptor );
     analyzer.setObjectFactory( MetaverseTestUtils.getMetaverseObjectFactory() );
     when( mockHTTP.getStepMetaInterface() ).thenReturn( meta );
-    when( mockHTTP.getStepMeta() ).thenReturn( mockStepMeta );
-    when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
-
+    lenient().when( mockHTTP.getStepMeta() ).thenReturn( mockStepMeta );
+    lenient().when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
   }
 
   @Test
@@ -209,14 +218,14 @@ public class HTTPClientStepAnalyzerTest extends ClonableStepAnalyzerTest
     when( meta.isUrlInField() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( meta ) );
     assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
       .thenReturn( "/path/to/row/file" );
     resources = consumer.getResourcesFromRow( mockHTTP, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
+      .thenThrow( KettleValueException.class );
     resources = consumer.getResourcesFromRow( mockHTTP, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/httppost/HTTPPostStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/httppost/HTTPPostStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -53,13 +53,23 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class HTTPPostStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private HTTPPostStepAnalyzer analyzer;
@@ -84,8 +94,8 @@ public class HTTPPostStepAnalyzerTest extends ClonableStepAnalyzerTest {
     analyzer.setObjectFactory( MetaverseTestUtils.getMetaverseObjectFactory() );
 
     when( mockHTTPPost.getStepMetaInterface() ).thenReturn( meta );
-    when( mockHTTPPost.getStepMeta() ).thenReturn( mockStepMeta );
-    when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( mockHTTPPost.getStepMeta() ).thenReturn( mockStepMeta );
+    lenient().when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
   }
 
   @Test
@@ -209,14 +219,14 @@ public class HTTPPostStepAnalyzerTest extends ClonableStepAnalyzerTest {
     when( this.meta.isUrlInField() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( this.meta ) );
     assertTrue( consumer.getResourcesFromMeta( this.meta ).isEmpty() );
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
       .thenReturn( "/path/to/row/file" );
     resources = consumer.getResourcesFromRow( mockHTTPPost, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
+      .thenThrow( KettleValueException.class );
     resources = consumer.getResourcesFromRow( mockHTTPPost, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/mergejoin/MergeJoinStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/mergejoin/MergeJoinStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
@@ -50,12 +50,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class MergeJoinStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private MergeJoinStepAnalyzer analyzer;
@@ -77,8 +86,8 @@ public class MergeJoinStepAnalyzerTest extends ClonableStepAnalyzerTest {
   @Before
   public void setUp() throws Exception {
 
-    when( mergeJoinMeta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( mergeJoinMeta.getParentStepMeta() ).thenReturn( parentStepMeta );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
 
     analyzer = spy( new MergeJoinStepAnalyzer() );
     analyzer.setParentStepMeta( parentStepMeta );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/numberrange/NumberRangeStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/numberrange/NumberRangeStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,14 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.numberrange.NumberRangeMeta;
 import org.pentaho.di.trans.steps.numberrange.NumberRangeRule;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 import org.pentaho.metaverse.api.model.IOperation;
 import org.pentaho.metaverse.api.model.Operations;
 
@@ -42,11 +41,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class NumberRangeStepAnalyzerTest {
 
   NumberRangeStepAnalyzer analyzer = null;
@@ -82,11 +88,11 @@ public class NumberRangeStepAnalyzerTest {
   public void testGetUsedFields() throws Exception {
     Set<StepField> fields = new HashSet<>();
     fields.add( new StepField( "prev", "inField" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     int expectedUsedFieldCount = 1;
     assertEquals( expectedUsedFieldCount, usedFields.size() );
-    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any( StepNodes.class ) );
+    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/rowstoresult/RowsToResultStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/rowstoresult/RowsToResultStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.rowstoresult.RowsToResultMeta;
 import org.pentaho.metaverse.analyzer.kettle.step.ClonableStepAnalyzerTest;
@@ -35,12 +35,15 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.IClonableStepAnalyzer;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by rfellows on 4/3/15.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RowsToResultStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   protected RowsToResultStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/selectvalues/SelectValuesStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/selectvalues/SelectValuesStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.TransMeta;
@@ -46,10 +46,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class SelectValuesStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   private static final String DEFAULT_STEP_NAME = "testStep";
@@ -139,13 +147,13 @@ public class SelectValuesStepAnalyzerTest extends ClonableStepAnalyzerTest {
     when( rmi.searchValueMeta( "first" ) ).thenReturn( vmiFirst );
     when( rmi.searchValueMeta( "last" ) ).thenReturn( vmiLast );
 
-    when( vmiFirst.getName() ).thenReturn( "first" );
-    when( vmiFirst.getCurrencySymbol() ).thenReturn( "$" );
-    when( vmiFirst.getStorageType() ).thenReturn( ValueMetaInterface.STORAGE_TYPE_NORMAL );
-    when( vmiLast.getDateFormatLocale() ).thenReturn( Locale.US );
-    when( vmiLast.getGroupingSymbol() ).thenReturn( "," );
+    lenient().when( vmiFirst.getName() ).thenReturn( "first" );
+    lenient().when( vmiFirst.getCurrencySymbol() ).thenReturn( "$" );
+    lenient().when( vmiFirst.getStorageType() ).thenReturn( ValueMetaInterface.STORAGE_TYPE_NORMAL );
+    lenient().when( vmiLast.getDateFormatLocale() ).thenReturn( Locale.US );
+    lenient().when( vmiLast.getGroupingSymbol() ).thenReturn( "," );
 
-    when( vmiLast.getName() ).thenReturn( "last" );
+    lenient().when( vmiLast.getName() ).thenReturn( "last" );
     when( vmiLast.getConversionMask() ).thenReturn( "000.##" );
     when( vmiLast.getDateFormatTimeZone() ).thenReturn( TimeZone.getDefault() );
     when( vmiLast.getDecimalSymbol() ).thenReturn( "." );
@@ -209,9 +217,9 @@ public class SelectValuesStepAnalyzerTest extends ClonableStepAnalyzerTest {
     String[] selected = new String[] { "AGE" };
     SelectMetadataChange[] changed = new SelectMetadataChange[] { testChange1, testChange2 };
 
-    when( selectValuesMeta.getDeleteName() ).thenReturn( deleted );
-    when( selectValuesMeta.getSelectName() ).thenReturn( selected );
-    when( selectValuesMeta.getMeta() ).thenReturn( changed );
+    lenient().when( selectValuesMeta.getDeleteName() ).thenReturn( deleted );
+    lenient().when( selectValuesMeta.getSelectName() ).thenReturn( selected );
+    lenient().when( selectValuesMeta.getMeta() ).thenReturn( changed );
 
     StepField stepField = new StepField( "previousStep", "first" );
     assertFalse( analyzer.isPassthrough( stepField ) );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/splitfields/SplitFieldsStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/splitfields/SplitFieldsStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.fieldsplitter.FieldSplitterMeta;
 import org.pentaho.dictionary.DictionaryConst;
@@ -35,7 +35,6 @@ import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 import org.pentaho.metaverse.api.model.IOperation;
 import org.pentaho.metaverse.api.model.Operations;
 
@@ -45,10 +44,16 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class SplitFieldsStepAnalyzerTest {
 
   private SplitFieldsStepAnalyzer analyzer;
@@ -97,11 +102,11 @@ public class SplitFieldsStepAnalyzerTest {
   public void testGetUsedFields() throws Exception {
     Set<StepField> fields = new HashSet<>();
     fields.add( new StepField( "prev", "splitField" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     int expectedUsedFieldCount = 1;
     assertEquals( expectedUsedFieldCount, usedFields.size() );
-    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any( StepNodes.class ) );
+    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/streamlookup/StreamLookupStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/streamlookup/StreamLookupStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.TransMeta;
@@ -48,13 +49,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StreamLookupStepAnalyzerTest {
 
   private StreamLookupStepAnalyzer analyzer;
@@ -136,22 +146,22 @@ public class StreamLookupStepAnalyzerTest {
 
     when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
 
-    when( stepIoMeta.getInfoStreams() ).thenReturn( streams );
-    when( stepMeta1.getName() ).thenReturn( "step1" );
-    when( stepMeta2.getName() ).thenReturn( "step2" );
-    when( stream1.getStepMeta() ).thenReturn( stepMeta1 );
-    when( stream1.getStepname() ).thenReturn( "step1" );
-    when( stream2.getStepMeta() ).thenReturn( stepMeta2 );
-    when( stream2.getStepname() ).thenReturn( "step2" );
-    when( parentTransMeta.getStepFields( stepMeta1 ) ).thenReturn( rowMeta1 );
-    when( parentTransMeta.getStepFields( stepMeta2 ) ).thenReturn( rowMeta2 );
-    when( parentTransMeta.getStepFields( parentStepMeta ) ).thenReturn( stepRowMeta );
-    when( parentTransMeta.getStepFields( "step1" ) ).thenReturn( step1RowMeta );
-    when( parentTransMeta.getStepFields( "step2" ) ).thenReturn( step2RowMeta );
-    when( step1RowMeta.searchValueMeta( anyString() ) ).thenReturn( mock( ValueMetaInterface.class ) );
+    lenient().when( stepIoMeta.getInfoStreams() ).thenReturn( streams );
+    lenient().when( stepMeta1.getName() ).thenReturn( "step1" );
+    lenient().when( stepMeta2.getName() ).thenReturn( "step2" );
+    lenient().when( stream1.getStepMeta() ).thenReturn( stepMeta1 );
+    lenient().when( stream1.getStepname() ).thenReturn( "step1" );
+    lenient().when( stream2.getStepMeta() ).thenReturn( stepMeta2 );
+    lenient().when( stream2.getStepname() ).thenReturn( "step2" );
+    lenient().when( parentTransMeta.getStepFields( eq( stepMeta1 ), any() ) ).thenReturn( rowMeta1 );
+    lenient().when( parentTransMeta.getStepFields( eq( stepMeta2 ), any() ) ).thenReturn( rowMeta2 );
+    lenient().when( parentTransMeta.getStepFields( eq( parentStepMeta ), any() ) ).thenReturn( stepRowMeta );
+    lenient().when( parentTransMeta.getStepFields( "step1" ) ).thenReturn( step1RowMeta );
+    lenient().when( parentTransMeta.getStepFields( "step2" ) ).thenReturn( step2RowMeta );
+    lenient().when( step1RowMeta.searchValueMeta( anyString() ) ).thenReturn( mock( ValueMetaInterface.class ) );
     String[] stepNames = { "step1", "step2" };
-    when( parentTransMeta.getPrevStepNames( any( StepMeta.class ) ) ).thenReturn( stepNames );
-    when( parentTransMeta.getPrevStepNames( anyString() ) ).thenReturn( stepNames );
+    when( parentTransMeta.getPrevStepNames( Mockito.<StepMeta>any() ) ).thenReturn( stepNames );
+    when( parentTransMeta.getPrevStepNames( Mockito.<String>any() ) ).thenReturn( stepNames );
 
     analyzer = spy( new StreamLookupStepAnalyzer() );
     analyzer.setParentStepMeta( parentStepMeta );
@@ -164,11 +174,11 @@ public class StreamLookupStepAnalyzerTest {
 
     when( analyzer.getInputs() ).thenReturn( inputs );
 
-    when( analyzer.getOutputFields( any( StreamLookupMeta.class ) ) ).thenReturn( outputRowMeta );
+    lenient().when( analyzer.getOutputFields( any( StreamLookupMeta.class ) ) ).thenReturn( outputRowMeta );
     ValueMetaInterface searchFieldResult = mock( ValueMetaInterface.class );
-    when( outputRowMeta.searchValueMeta( anyString() ) ).thenReturn( searchFieldResult );
-    when( searchFieldResult.getOrigin() ).thenReturn( "step1" );
-    when( searchFieldResult.getName() ).thenReturn( "country_code" );
+    lenient().when( outputRowMeta.searchValueMeta( anyString() ) ).thenReturn( searchFieldResult );
+    lenient().when( searchFieldResult.getOrigin() ).thenReturn( "step1" );
+    lenient().when( searchFieldResult.getName() ).thenReturn( "country_code" );
   }
 
   @Test
@@ -176,8 +186,8 @@ public class StreamLookupStepAnalyzerTest {
 
     analyzer.customAnalyze( streamLookupMeta, node );
 
-    verify( builder, times( 2 * mockKeylookup.length ) ).addLink( any( IMetaverseNode.class ),
-      eq( DictionaryConst.LINK_JOINS ), any( IMetaverseNode.class ) );
+    verify( builder, times( 2 * mockKeylookup.length ) ).addLink( Mockito.<IMetaverseNode>any(),
+      eq( DictionaryConst.LINK_JOINS ), Mockito.<IMetaverseNode>any() );
 
   }
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringoperations/StringOperationsStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringoperations/StringOperationsStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,26 +26,32 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.stringoperations.StringOperationsMeta;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StringOperationsStepAnalyzerTest {
 
   private StringOperationsStepAnalyzer analyzer;
@@ -94,7 +100,7 @@ public class StringOperationsStepAnalyzerTest {
               getPaddingCode( StringOperationsMeta.PADDING_NONE ),
               getPaddingCode( StringOperationsMeta.PADDING_NONE )
         });
-    when( stringOperationsMeta.getPadChar() ).thenReturn( new String[]{ "", "", "" } );
+//    when( stringOperationsMeta.getPadChar() ).thenReturn( new String[]{ "", "", "" } );
     when( stringOperationsMeta.getPadLen() ).thenReturn( new String[]{ "", "", "" } );
     when( stringOperationsMeta.getRemoveSpecialCharacters() ).thenReturn(
       new String[]{
@@ -127,7 +133,7 @@ public class StringOperationsStepAnalyzerTest {
     fields.add( new StepField( "prev", "firstName" ) );
     fields.add( new StepField( "prev", "middleName" ) );
     fields.add( new StepField( "prev", "lastName" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( stringOperationsMeta );
     List<String> inFields = Arrays.asList( stringOperationsMeta.getFieldInStream() );
     // This test class uses all incoming fields

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringscut/StringsCutStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringscut/StringsCutStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,26 +26,32 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.stringcut.StringCutMeta;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StringsCutStepAnalyzerTest {
 
   private StringsCutStepAnalyzer analyzer;
@@ -86,7 +92,7 @@ public class StringsCutStepAnalyzerTest {
     fields.add( new StepField( "prev", "firstName" ) );
     fields.add( new StepField( "prev", "middleName" ) );
     fields.add( new StepField( "prev", "lastName" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( stringsCutMeta );
     List<String> inFields = Arrays.asList( stringsCutMeta.getFieldInStream() );
     // This test class uses all incoming fields

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringsreplace/StringsReplaceStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/stringsreplace/StringsReplaceStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.replacestring.ReplaceStringMeta;
@@ -43,12 +43,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class StringsReplaceStepAnalyzerTest {
 
   private StringsReplaceStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputExternalResourceConsumerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputExternalResourceConsumerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.trans.steps.tableinput.TableInputMeta;
@@ -38,12 +38,14 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by rfellows on 5/29/15.
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TableInputExternalResourceConsumerTest {
 
   TableInputExternalResourceConsumer consumer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableinput/TableInputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.tableinput.TableInputMeta;
@@ -47,13 +47,22 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by rfellows on 5/29/15.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TableInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
 
   TableInputStepAnalyzer analyzer;
@@ -75,7 +84,6 @@ public class TableInputStepAnalyzerTest extends ClonableStepAnalyzerTest {
   @Before
   public void setUp() throws Exception {
     analyzer = spy( new TableInputStepAnalyzer() );
-    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
     descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_TRANS_STEP, mockNamespace );
     analyzer.setDescriptor( descriptor );
     analyzer.setBaseStepMeta( meta );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputExternalResourceConsumerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputExternalResourceConsumerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.trans.TransMeta;
@@ -39,9 +39,10 @@ import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TableOutputExternalResourceConsumerTest {
 
   TableOutputExternalResourceConsumer consumer;
@@ -71,9 +72,9 @@ public class TableOutputExternalResourceConsumerTest {
     when( meta.getSchemaName() ).thenReturn( "schemaName" );
 
     when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
-    when( parentTransMeta.environmentSubstitute( "tableName" ) ).thenReturn( "tableName" );
-    when( parentTransMeta.environmentSubstitute( "schemaName" ) ).thenReturn( "schemaName" );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( parentTransMeta.environmentSubstitute( "tableName" ) ).thenReturn( "tableName" );
+    lenient().when( parentTransMeta.environmentSubstitute( "schemaName" ) ).thenReturn( "schemaName" );
 
     when( dbMeta.getAccessTypeDesc() ).thenReturn( "JNDI" );
     when( dbMeta.getName() ).thenReturn( "TestConnection" );
@@ -90,7 +91,6 @@ public class TableOutputExternalResourceConsumerTest {
 
     assertEquals( "tableName", res.getAttributes().get( DictionaryConst.PROPERTY_TABLE ) );
     assertEquals( "schemaName", res.getAttributes().get( DictionaryConst.PROPERTY_SCHEMA ) );
-
   }
 
   @Test
@@ -103,10 +103,10 @@ public class TableOutputExternalResourceConsumerTest {
     when( meta.getTableName() ).thenReturn( "tableName" );
     when( meta.getSchemaName() ).thenReturn( "schemaName" );
 
-    when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
-    when( parentTransMeta.environmentSubstitute( "tableName" ) ).thenReturn( "tableName" );
-    when( parentTransMeta.environmentSubstitute( "schemaName" ) ).thenReturn( "schemaName" );
+    lenient().when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( parentTransMeta.environmentSubstitute( "tableName" ) ).thenReturn( "tableName" );
+    lenient().when( parentTransMeta.environmentSubstitute( "schemaName" ) ).thenReturn( "schemaName" );
 
     when( dbMeta.getAccessTypeDesc() ).thenReturn( "JNDI" );
     when( dbMeta.getName() ).thenReturn( "TestConnection" );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/tableoutput/TableOutputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.row.RowMeta;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -49,24 +48,25 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 import org.pentaho.metaverse.api.model.BaseDatabaseResourceInfo;
 import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author mburgess
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TableOutputStepAnalyzerTest {
 
   private TableOutputStepAnalyzer analyzer;
@@ -100,14 +100,14 @@ public class TableOutputStepAnalyzerTest {
     analyzer.setParentTransMeta( parentTransMeta );
     analyzer.setParentStepMeta( parentStepMeta );
 
-    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
+    lenient().when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
     descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_TRANS_STEP, mockNamespace );
     analyzer.setDescriptor( descriptor );
 
-    when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
-    when( parentStepMeta.getName() ).thenReturn( "test" );
-    when( parentStepMeta.getStepID() ).thenReturn( "TableOutputStep" );
+    lenient().when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    lenient().when( parentStepMeta.getName() ).thenReturn( "test" );
+    lenient().when( parentStepMeta.getStepID() ).thenReturn( "TableOutputStep" );
 
     when( parentTransMeta.environmentSubstitute( TABLE_NAME ) ).thenReturn( TABLE_NAME );
   }
@@ -133,12 +133,6 @@ public class TableOutputStepAnalyzerTest {
 
   @Test
   public void testCreateTableNode() throws Exception {
-    IConnectionAnalyzer connectionAnalyzer = mock( IConnectionAnalyzer.class );
-
-    doReturn( connectionAnalyzer ).when( analyzer ).getConnectionAnalyzer();
-    IMetaverseNode connNode = mock( IMetaverseNode.class );
-    when( connectionAnalyzer.analyze( any( IComponentDescriptor.class ), anyObject() ) ).thenReturn( connNode );
-
     BaseDatabaseResourceInfo resourceInfo = mock( BaseDatabaseResourceInfo.class );
     Map<Object, Object> attributes = new HashMap<>();
     attributes.put( DictionaryConst.PROPERTY_TABLE, TABLE_NAME );
@@ -158,12 +152,6 @@ public class TableOutputStepAnalyzerTest {
 
   @Test
   public void testCreateTableNode_nullSchema() throws Exception {
-    IConnectionAnalyzer connectionAnalyzer = mock( IConnectionAnalyzer.class );
-
-    doReturn( connectionAnalyzer ).when( analyzer ).getConnectionAnalyzer();
-    IMetaverseNode connNode = mock( IMetaverseNode.class );
-    when( connectionAnalyzer.analyze( any( IComponentDescriptor.class ), anyObject() ) ).thenReturn( connNode );
-
     BaseDatabaseResourceInfo resourceInfo = mock( BaseDatabaseResourceInfo.class );
     Map<Object, Object> attributes = new HashMap<>();
     attributes.put( DictionaryConst.PROPERTY_TABLE, TABLE_NAME );
@@ -182,13 +170,6 @@ public class TableOutputStepAnalyzerTest {
 
   @Test
   public void testCreateTableNode_nullTable() throws Exception {
-    IConnectionAnalyzer connectionAnalyzer = mock( IConnectionAnalyzer.class );
-
-    doReturn( connectionAnalyzer ).when( analyzer ).getConnectionAnalyzer();
-    IMetaverseNode connNode = mock( IMetaverseNode.class );
-    when( connectionAnalyzer.analyze( any( IComponentDescriptor.class ), anyObject() ) ).thenReturn( connNode );
-
-
     BaseDatabaseResourceInfo resourceInfo = mock( BaseDatabaseResourceInfo.class );
     Map<Object, Object> attributes = new HashMap<>();
     when( resourceInfo.getAttributes() ).thenReturn( attributes );
@@ -232,9 +213,9 @@ public class TableOutputStepAnalyzerTest {
   @Test
   public void testGetOutputResourceFieldsRenamed() throws Exception {
     String[] tableFields = new String[] { "foo", "foe", "fee" };
-    when( meta.getFieldDatabase() ).thenReturn( tableFields );
+    lenient().when( meta.getFieldDatabase() ).thenReturn( tableFields );
     String[] streamFields = new String[] { "field2", "field3", "bogus" };
-    when( meta.getFieldStream() ).thenReturn( streamFields );
+    lenient().when( meta.getFieldStream() ).thenReturn( streamFields );
 
     RowMetaInterface rmi = Mockito.mock( RowMetaInterface.class );
     String[] outputFields = new String[2];

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/textfileinput/TextFileInputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.exception.KettleException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.TransMeta;
@@ -47,11 +47,16 @@ import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TextFileInputStepAnalyzerTest {
 
   private TextFileInputStepAnalyzer analyzer;
@@ -78,21 +83,21 @@ public class TextFileInputStepAnalyzerTest {
 
     mockFactory = MetaverseTestUtils.getMetaverseObjectFactory();
     when( mockBuilder.getMetaverseObjectFactory() ).thenReturn( mockFactory );
-    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
+    lenient().when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
 
     analyzer = new TextFileInputStepAnalyzer();
     analyzer.setMetaverseBuilder( mockBuilder );
 
-    when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
-    when( mockTextFileInput.getStepMeta() ).thenReturn( mockStepMeta );
-    when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( mockTextFileInput.getStepMeta() ).thenReturn( mockStepMeta );
+    lenient().when( mockStepMeta.getStepMetaInterface() ).thenReturn( meta );
   }
 
   @Test
   public void testGetUsedFields_fileNameFromField() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( true );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 1, usedFields.size() );
@@ -103,9 +108,9 @@ public class TextFileInputStepAnalyzerTest {
 
   @Test
   public void testGetUsedFields_isNotAcceptingFilenames() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( false );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( false );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( "previousStep" );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 0, usedFields.size() );
@@ -113,9 +118,9 @@ public class TextFileInputStepAnalyzerTest {
 
   @Test
   public void testGetUsedFields_isAcceptingFilenamesButNoStepName() throws Exception {
-    when( meta.isAcceptingFilenames() ).thenReturn( true );
-    when( meta.getAcceptingField() ).thenReturn( "filename" );
-    when( meta.getAcceptingStepName() ).thenReturn( null );
+    lenient().when( meta.isAcceptingFilenames() ).thenReturn( true );
+    lenient().when( meta.getAcceptingField() ).thenReturn( "filename" );
+    lenient().when( meta.getAcceptingStepName() ).thenReturn( null );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     assertNotNull( usedFields );
     assertEquals( 0, usedFields.size() );
@@ -158,8 +163,8 @@ public class TextFileInputStepAnalyzerTest {
     StepMeta spyMeta = spy( new StepMeta( "test", meta ) );
 
     when( meta.getParentStepMeta() ).thenReturn( spyMeta );
-    when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
-    when( meta.getFileName() ).thenReturn( null );
+    lenient().when( spyMeta.getParentTransMeta() ).thenReturn( transMeta );
+    lenient().when( meta.getFileName() ).thenReturn( null );
     when( meta.isAcceptingFilenames() ).thenReturn( false );
     String[] filePaths = { "/path/to/file1", "/another/path/to/file2" };
     when( meta.getFilePaths( Mockito.any( VariableSpace.class ) ) ).thenReturn( filePaths );
@@ -173,15 +178,15 @@ public class TextFileInputStepAnalyzerTest {
     when( meta.isAcceptingFilenames() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( meta ) );
     assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
+    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.any(), Mockito.any() ) )
       .thenReturn( "/path/to/row/file" );
     when( mockTextFileInput.getStepMetaInterface() ).thenReturn( meta );
     resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenThrow( KettleException.class );
+    when( mockRowMetaInterface.getString( Mockito.any(), Mockito.any(), Mockito.any() ) )
+      .thenThrow( KettleValueException.class );
     resources = consumer.getResourcesFromRow( mockTextFileInput, mockRowMetaInterface, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );
 

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/textfileoutput/TextFileOutputStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/textfileoutput/TextFileOutputStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.textfileoutput.TextFileField;
 import org.pentaho.di.trans.steps.textfileoutput.TextFileOutputMeta;
@@ -42,10 +42,17 @@ import org.pentaho.metaverse.testutils.MetaverseTestUtils;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TextFileOutputStepAnalyzerTest {
 
   private TextFileOutputStepAnalyzer analyzer;

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/transexecutor/TransExecutorStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/transexecutor/TransExecutorStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.ProgressMonitorListener;
@@ -70,13 +70,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -87,7 +88,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by rfellows on 4/2/15.
  */
-@SuppressWarnings( { "deprecation", "ResultOfMethodCallIgnored" } ) @RunWith( MockitoJUnitRunner.class )
+@SuppressWarnings( { "deprecation", "ResultOfMethodCallIgnored" } ) @RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransExecutorStepAnalyzerTest {
 
   @Mock
@@ -138,15 +139,15 @@ public class TransExecutorStepAnalyzerTest {
     when( parentTransMeta.getPrevStepFields( eq( nextStepMeta_Results ), any( ProgressMonitorListener.class ) ) )
       .thenReturn( nextStepMeta_Results_input );
 
-    when( nextStepMeta_Results_input.getFieldNames() ).thenReturn( resultsFieldNames );
+    lenient().when( nextStepMeta_Results_input.getFieldNames() ).thenReturn( resultsFieldNames );
 
 
     when( parentTransMeta.environmentSubstitute( anyString() ) ).then(
       (Answer<String>) invocationOnMock -> invocationOnMock.getArguments()[ 0 ].toString() );
 
-    when( childTransMeta.getName() ).thenReturn( "child" );
-    when( descriptor.getNamespace() ).thenReturn( namespace );
-    when( namespace.getParentNamespace() ).thenReturn( parentNamespace );
+    lenient().when( childTransMeta.getName() ).thenReturn( "child" );
+    lenient().when( descriptor.getNamespace() ).thenReturn( namespace );
+    lenient().when( namespace.getParentNamespace() ).thenReturn( parentNamespace );
 
     when( descriptor.getContext() ).thenReturn( analysisContext );
 
@@ -159,7 +160,7 @@ public class TransExecutorStepAnalyzerTest {
     spyAnalyzer.setParentTransMeta( parentTransMeta );
     spyAnalyzer.setParentStepMeta( parentStepMeta );
     spyAnalyzer.setDescriptor( descriptor );
-    doReturn( documentDescriptor ).when( spyAnalyzer ).getDocumentDescriptor();
+    lenient().doReturn( documentDescriptor ).when( spyAnalyzer ).getDocumentDescriptor();
   }
 
   @Test( expected = MetaverseAnalyzerException.class )
@@ -174,7 +175,6 @@ public class TransExecutorStepAnalyzerTest {
   public void testCustomAnalyze_fileName() throws Exception {
     String filePath = "src/it/resources/repo/validation/transformation-executor/trans-executor-child.ktr"
       .replace( "/", File.separator );
-    doReturn( childTransMeta ).when( spyAnalyzer ).getSubTransMeta( anyString() );
     when( meta.getFileName() ).thenReturn( filePath );
 
     when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.FILENAME );
@@ -226,8 +226,6 @@ public class TransExecutorStepAnalyzerTest {
   @Test( expected = MetaverseAnalyzerException.class )
   public void testCustomAnalyze_repoFile_NoRepo() throws Exception {
     // we should get an exception if the sub transformation isn't found in the repo
-    when( meta.getDirectoryPath() ).thenReturn( "/home/admin" );
-    when( meta.getTransName() ).thenReturn( "my.ktr" );
     when( parentTransMeta.getRepository() ).thenReturn( null );
     when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
     spyAnalyzer.customAnalyze( meta, node );
@@ -235,19 +233,19 @@ public class TransExecutorStepAnalyzerTest {
 
   @Test
   public void testCustomAnalyze_repoFile() throws Exception {
-    when( meta.getDirectoryPath() ).thenReturn( "/home/admin" );
-    when( meta.getTransName() ).thenReturn( "my" );
+    lenient().when( meta.getDirectoryPath() ).thenReturn( "/home/admin" );
+    lenient().when( meta.getTransName() ).thenReturn( "my" );
     Repository repo = mock( Repository.class );
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
-    when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
-    when( repo.loadTransformation( anyString(), eq( repoDir ), any( ProgressMonitorListener.class ),
+    lenient().when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
+    lenient().when( repo.loadTransformation( anyString(), eq( repoDir ), any( ProgressMonitorListener.class ),
       anyBoolean(), anyString() ) ).thenReturn( childTransMeta );
-    when( parentTransMeta.getRepository() ).thenReturn( repo );
+    lenient().when( parentTransMeta.getRepository() ).thenReturn( repo );
 
-    doReturn( childTransMeta ).when( spyAnalyzer ).getSubTransMeta( anyString() );
-    when( childTransMeta.getPathAndName() ).thenReturn( "/home/admin/my" );
-    when( childTransMeta.getDefaultExtension() ).thenReturn( "ktr" );
-    when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+    lenient().doReturn( childTransMeta ).when( spyAnalyzer ).getSubTransMeta( anyString() );
+    lenient().when( childTransMeta.getPathAndName() ).thenReturn( "/home/admin/my" );
+    lenient().when( childTransMeta.getDefaultExtension() ).thenReturn( "ktr" );
+    lenient().when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
 
 
     // don't bother running the connectX methods, we'll test those later
@@ -282,7 +280,7 @@ public class TransExecutorStepAnalyzerTest {
     when( meta.getTransObjectId() ).thenReturn( mock( ObjectId.class ) );
     Repository repo = mock( Repository.class );
     when( parentTransMeta.getRepository() ).thenReturn( repo );
-    when( repo.loadTransformation( any( ObjectId.class ), anyString() ) ).thenThrow( new KettleException() );
+    when( repo.loadTransformation( any( ObjectId.class ), any() ) ).thenThrow( new KettleException() );
     when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
     spyAnalyzer.customAnalyze( meta, node );
   }
@@ -290,7 +288,6 @@ public class TransExecutorStepAnalyzerTest {
   @Test( expected = MetaverseAnalyzerException.class )
   public void testCustomAnalyze_repoRepo_NoRepo() throws Exception {
     // we should get an exception if the sub transformation isn't found on the filesystem
-    when( meta.getTransObjectId() ).thenReturn( mock( ObjectId.class ) );
     when( parentTransMeta.getRepository() ).thenReturn( null );
     when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
     spyAnalyzer.customAnalyze( meta, node );
@@ -298,14 +295,14 @@ public class TransExecutorStepAnalyzerTest {
 
   @Test
   public void testCustomAnalyze_repoRef() throws Exception {
-    when( meta.getTransObjectId() ).thenReturn( mock( ObjectId.class ) );
+    lenient().when( meta.getTransObjectId() ).thenReturn( mock( ObjectId.class ) );
     Repository repo = mock( Repository.class );
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
-    when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
-    when( repo.loadTransformation( any( ObjectId.class ), anyString() ) ).thenReturn( childTransMeta );
-    when( parentTransMeta.getRepository() ).thenReturn( repo );
+    lenient().when( repo.findDirectory( anyString() ) ).thenReturn( repoDir );
+    lenient().when( repo.loadTransformation( any( ObjectId.class ), anyString() ) ).thenReturn( childTransMeta );
+    lenient().when( parentTransMeta.getRepository() ).thenReturn( repo );
 
-    doReturn( childTransMeta ).when( spyAnalyzer ).getSubTransMeta( anyString() );
+    lenient().doReturn( childTransMeta ).when( spyAnalyzer ).getSubTransMeta( anyString() );
     when( childTransMeta.getPathAndName() ).thenReturn( "/home/admin/my" );
     when( childTransMeta.getDefaultExtension() ).thenReturn( "ktr" );
     when( meta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
@@ -424,9 +421,6 @@ public class TransExecutorStepAnalyzerTest {
     StepNodes inputs = new StepNodes();
     doReturn( inputs ).when( spyAnalyzer ).getInputs();
 
-    doNothing().when( spyHelper ).linkUsedFieldToSubTrans( any( IMetaverseNode.class ), any( TransMeta.class ),
-      any( IMetaverseNode.class ), any( IComponentDescriptor.class ) );
-
     spyAnalyzer.connectToSubTransInputFields( childTransMeta, childTransNode, descriptor );
 
     verify( spyHelper, never() ).linkUsedFieldToSubTrans( any( IMetaverseNode.class ),
@@ -455,7 +449,6 @@ public class TransExecutorStepAnalyzerTest {
     RowsToResultMeta mockRowsToResultMeta = mock( RowsToResultMeta.class );
     when( rowsFromResult.getStepMetaInterface() ).thenReturn( mockRowsToResultMeta );
     when( mockRowsToResultMeta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( mockRowsToResultMeta.getName() ).thenReturn( "stepName" );
     childTransSteps.add( rowsFromResult );
 
     RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
@@ -465,14 +458,14 @@ public class TransExecutorStepAnalyzerTest {
 
     IMetaverseNode subFieldNode = mock( IMetaverseNode.class );
     doReturn( subFieldNode ).when( spyAnalyzer ).createFieldNode( any( IComponentDescriptor.class ),
-      any( ValueMetaInterface.class ),
+      any(),
       eq( StepAnalyzer.NONE ),
       eq( false ) );
 
     spyHelper.linkResultFieldToSubTrans( fieldNode, childTransMeta, childTransNode, descriptor );
 
     verify( spyAnalyzer ).createFieldNode( any( IComponentDescriptor.class ),
-      any( ValueMetaInterface.class ),
+      any(),
       eq( StepAnalyzer.NONE ),
       eq( false ) );
 
@@ -512,8 +505,6 @@ public class TransExecutorStepAnalyzerTest {
     when( rowsFromResult.getStepMetaInterface() ).thenReturn( mockRowsFromResultMeta );
     when( rowsFromResult.getName() ).thenReturn( "stepName" );
     childTransSteps.add( rowsFromResult );
-
-    when( mockRowsFromResultMeta.getFieldname() ).thenReturn( resultsFieldNames );
 
     StepMeta rowsParentStepMeta = mock( StepMeta.class );
     TransMeta rowsParentTransMeta = mock( TransMeta.class );

--- a/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/analyzer/kettle/step/valuemapper/ValueMapperStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,14 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.valuemapper.ValueMapperMeta;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.IMetaverseNode;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
-import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
 import org.pentaho.metaverse.api.model.IOperation;
 import org.pentaho.metaverse.api.model.Operations;
 
@@ -41,12 +40,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class ValueMapperStepAnalyzerTest {
 
   private ValueMapperStepAnalyzer analyzer = null;
@@ -69,18 +75,18 @@ public class ValueMapperStepAnalyzerTest {
   @Test
   public void testCustomAnalyze() throws Exception {
     analyzer.customAnalyze( meta, node );
-    verify( node ).setProperty( eq( "defaultValue" ), anyString() );
+    verify( node ).setProperty( eq( "defaultValue" ), any() );
   }
 
   @Test
   public void testGetUsedFields() throws Exception {
     Set<StepField> fields = new HashSet<>();
     fields.add( new StepField( "prev", "inField" ) );
-    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any( StepNodes.class ) );
+    doReturn( fields ).when( analyzer ).createStepFields( anyString(), any() );
     Set<StepField> usedFields = analyzer.getUsedFields( meta );
     int expectedUsedFieldCount = 1;
     assertEquals( expectedUsedFieldCount, usedFields.size() );
-    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any( StepNodes.class ) );
+    verify( analyzer, times( expectedUsedFieldCount ) ).createStepFields( anyString(), any() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/graph/SynchronizedGraphTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/graph/SynchronizedGraphTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,11 +29,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class SynchronizedGraphTest {
 
   private SynchronizedGraph synchronizedGraph;

--- a/core/src/test/java/org/pentaho/metaverse/impl/DocumentControllerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/DocumentControllerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.metaverse.api.IAnalyzer;
 import org.pentaho.metaverse.api.IComponentDescriptor;
 import org.pentaho.metaverse.api.IDocument;
@@ -43,12 +43,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DocumentControllerTest {
 
   private DocumentController docController;

--- a/core/src/test/java/org/pentaho/metaverse/impl/DocumentEventTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/DocumentEventTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,16 +30,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.metaverse.api.IDocument;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author mburgess
  * 
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DocumentEventTest {
 
   DocumentEvent docEvent;

--- a/core/src/test/java/org/pentaho/metaverse/impl/FileSystemLineageCollectorTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/FileSystemLineageCollectorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,9 +32,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Created by rfellows on 7/6/15.

--- a/core/src/test/java/org/pentaho/metaverse/impl/MetaverseNodeTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/MetaverseNodeTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,10 +39,20 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author mburgess

--- a/core/src/test/java/org/pentaho/metaverse/impl/VfsLineageCollectorTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/VfsLineageCollectorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,21 +22,21 @@
 
 package org.pentaho.metaverse.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.List;
 
-import org.apache.commons.io.FilenameUtils;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Created by rfellows on 7/6/15.

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/AbstractStepMetaJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/AbstractStepMetaJsonSerializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -61,13 +61,21 @@ import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * User: RFellows Date: 12/1/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class AbstractStepMetaJsonSerializerTest {
 
   public static final String STEP_META_NAME = "StepMetaName";
@@ -113,7 +121,7 @@ public class AbstractStepMetaJsonSerializerTest {
     verify( json ).writeStartObject();
     verify( json ).writeStringField( IInfo.JSON_PROPERTY_CLASS, spyMeta.getClass().getName() );
     verify( json ).writeStringField( IInfo.JSON_PROPERTY_NAME, spyParent.getName() );
-    verify( json ).writeStringField( eq( AbstractStepMetaJsonSerializer.JSON_PROPERTY_TYPE ), anyString() );
+    verify( json ).writeStringField( eq( AbstractStepMetaJsonSerializer.JSON_PROPERTY_TYPE ), any() );
 
     // make sure the templated methods are called
     verify( spySerializer ).writeRepoAttributes( spyMeta, json );
@@ -158,8 +166,6 @@ public class AbstractStepMetaJsonSerializerTest {
   public void testWriteInputFields() throws Exception {
     serializer = new BaseStepMetaJsonSerializer( BaseStepMeta.class );
     serializer.setLineageRepository( repo );
-
-    when( spyParent.getParentTransMeta() ).thenReturn( spyParentTrans );
 
     IFieldLineageMetadataProvider mapper = mock( IFieldLineageMetadataProvider.class );
     AbstractStepMetaJsonSerializer spy = spy( serializer );
@@ -218,7 +224,7 @@ public class AbstractStepMetaJsonSerializerTest {
     externalResources.add( info );
 
     IStepExternalResourceConsumer consumer = mock( IStepExternalResourceConsumer.class );
-    when( consumer.getResourcesFromMeta( anyObject() ) ).thenReturn( externalResources );
+    when( consumer.getResourcesFromMeta( any() ) ).thenReturn( externalResources );
     consumers.add( consumer );
 
     Class<? extends BaseStepMeta> stepMetaClass = BaseStepMeta.class;
@@ -230,7 +236,7 @@ public class AbstractStepMetaJsonSerializerTest {
 
     verify( mockConsumerMap ).getExternalResourceConsumers( any( Collection.class ) );
     verify( json ).writeArrayFieldStart( AbstractStepMetaJsonSerializer.JSON_PROPERTY_EXTERNAL_RESOURCES );
-    verify( consumer ).getResourcesFromMeta( anyObject() );
+    verify( consumer ).getResourcesFromMeta( any() );
     verify( json, times( externalResources.size() ) ).writeObject( any( IExternalResourceInfo.class ) );
     verify( json ).writeEndArray();
   }

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobEntryBaseJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobEntryBaseJsonSerializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryBase;
@@ -42,14 +42,18 @@ import org.pentaho.metaverse.impl.model.kettle.LineageRepository;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobEntryBaseJsonSerializerTest {
 
   JobEntryBaseJsonSerializer serializer;

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobMetaJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobMetaJsonSerializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.job.JobHopMeta;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.success.JobEntrySuccess;
@@ -38,11 +38,14 @@ import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.metaverse.api.model.kettle.HopInfo;
 import org.pentaho.metaverse.impl.model.kettle.LineageRepository;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JobMetaJsonSerializerTest {
 
   JobMetaJsonSerializer serializer;

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TableOutputStepMetaJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TableOutputStepMetaJsonSerializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.trans.steps.tableoutput.TableOutputMeta;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.spy;
 /**
  * User: RFellows Date: 12/1/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TableOutputStepMetaJsonSerializerTest {
 
   TableOutputStepMetaJsonSerializer serializer;

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TransMetaJsonDeserializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TransMetaJsonDeserializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -33,7 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -57,16 +57,22 @@ import java.util.Map;
 
 import static com.tinkerpop.frames.util.Validate.assertNotNull;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * User: RFellows Date: 12/2/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransMetaJsonDeserializerTest {
 
   TransMetaJsonDeserializer deserializer;
@@ -236,13 +242,13 @@ public class TransMetaJsonDeserializerTest {
   @Test
   public void testDeserializeHops() throws Exception {
     transMeta = spy( new TransMeta() );
-    when( transMeta.findStep( "from" ) ).thenReturn( fromStep );
-    when( transMeta.findStep( "to" ) ).thenReturn( toStep );
-    when( mapper.readValue( "to be mocked", HopInfo.class ) ).thenReturn( hop0 );
-    when( root_hopsArray_hop0.toString() ).thenReturn( "to be mocked" ); // mocked, value does not matter
-    when( hop0.isEnabled() ).thenReturn( true );
-    when( hop0.getFromStepName() ).thenReturn( "from" );
-    when( hop0.getToStepName() ).thenReturn( "to" );
+    doReturn( fromStep ).when( transMeta).findStep( "from" );
+    doReturn( toStep ).when( transMeta).findStep( "to" );
+    doReturn( hop0 ).when( mapper).readValue( "to be mocked", HopInfo.class );
+    doReturn( "to be mocked" ).when( root_hopsArray_hop0).toString();
+    doReturn( true ).when( hop0).isEnabled();
+    doReturn( "from" ).when( hop0).getFromStepName();
+    doReturn( "to" ).when( hop0).getToStepName();
 
     deserializer.deserializeHops( transMeta, root, mapper );
 
@@ -325,11 +331,12 @@ public class TransMetaJsonDeserializerTest {
     verify( repo ).saveStepAttribute( null, stepId, 0, "name", "Test 1" );
     verify( repo ).saveStepAttribute( null, stepId, 1, "name", "Test 2" );
 
-    verify( repo, times( 2 ) ).saveStepAttribute( any( ObjectId.class ), eq( stepId ), anyInt(), eq( "int" ), anyInt() );
-    verify( repo, times( 2 ) ).saveStepAttribute( any( ObjectId.class ), eq( stepId ), anyInt(), eq( "long" ), eq( 3L ) );
-    verify( repo, times( 2 ) ).saveStepAttribute( any( ObjectId.class ), eq( stepId ), anyInt(), eq( "double" ), eq( 3.0D ) );
-    verify( repo, times( 2 ) ).saveStepAttribute( any( ObjectId.class ), eq( stepId ), anyInt(), eq( "bool" ), eq( true ) );
-    verify( repo, times( 2 ) ).saveStepAttribute( any( ObjectId.class ), eq( stepId ), anyInt(), eq( "null" ), anyString() ) ;
+    // Matching on a Long for first "int" verify because of new mocking behavior -- there is no overload of Repository.saveStepAttribute() with an Integer argument
+    verify( repo, times( 2 ) ).saveStepAttribute( any(), eq( stepId ), anyInt(), eq( "int" ), eq( 2L ) );
+    verify( repo, times( 2 ) ).saveStepAttribute( any(), eq( stepId ), anyInt(), eq( "long" ), eq( 3L ) );
+    verify( repo, times( 2 ) ).saveStepAttribute( any(), eq( stepId ), anyInt(), eq( "double" ), eq( 3.0D ) );
+    verify( repo, times( 2 ) ).saveStepAttribute( any(), eq( stepId ), anyInt(), eq( "bool" ), eq( true ) );
+    verify( repo, times( 2 ) ).saveStepAttribute( any(), eq( stepId ), anyInt(), eq( "null" ), isNull() ) ;
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TransMetaJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/TransMetaJsonSerializerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,7 +30,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -42,7 +42,6 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.dummytrans.DummyTransMeta;
-import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metaverse.api.model.BaseResourceInfo;
 import org.pentaho.metaverse.api.model.IInfo;
 import org.pentaho.metaverse.api.model.IParamInfo;
@@ -54,12 +53,18 @@ import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * User: RFellows Date: 12/1/14
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class TransMetaJsonSerializerTest {
 
   TransMetaJsonSerializer serializer;
@@ -167,19 +172,15 @@ public class TransMetaJsonSerializerTest {
     when( spyStep2.getStepMetaInterface() ).thenReturn( spyDummy2 );
     when( spyStep3.getStepMetaInterface() ).thenReturn( spyDummy3 );
 
-    doThrow( new KettleException() ).when( spyDummy3 ).saveRep( any( Repository.class ), any( IMetaStore.class ),
-      any( ObjectId.class ), any( ObjectId.class ) );
+    doThrow( new KettleException() ).when( spyDummy3 ).saveRep( any( Repository.class ), any( ), any(), any( ObjectId.class ) );
 
     serializer.serializeSteps( transMeta, json );
 
     verify( json ).writeArrayFieldStart( TransMetaJsonSerializer.JSON_PROPERTY_STEPS );
     // make sure we call the saveRep method for each step to collect the common attribute stuff
-    verify( spyDummy1 ).saveRep( any( Repository.class ), any( IMetaStore.class ),
-      any( ObjectId.class ), any( ObjectId.class ) );
-    verify( spyDummy2 ).saveRep( any( Repository.class ), any( IMetaStore.class ),
-      any( ObjectId.class ), any( ObjectId.class ) );
-    verify( spyDummy3 ).saveRep( any( Repository.class ), any( IMetaStore.class ),
-      any( ObjectId.class ), any( ObjectId.class ) );
+    verify( spyDummy1 ).saveRep( any( Repository.class ), any( ), any(), any( ObjectId.class ) );
+    verify( spyDummy2 ).saveRep( any( Repository.class ), any( ), any(), any( ObjectId.class ) );
+    verify( spyDummy3 ).saveRep( any( Repository.class ), any( ), any(), any( ObjectId.class ) );
 
     // make sure we are writing out each step
     verify( json ).writeObject( spyDummy1 );
@@ -201,7 +202,6 @@ public class TransMetaJsonSerializerTest {
     when( db1.getAccessTypeDesc() ).thenReturn( "Native" );
     when( db1.getName() ).thenReturn( "DB1" );
     when( db1.getDatabasePortNumberString() ).thenReturn( "5432" );
-    when( db1.getServername() ).thenReturn( "localhost" );
     when( db1.getDescription() ).thenReturn( null );
     when( db1.getUsername() ).thenReturn( "user" );
     when( db1.getPassword() ).thenReturn( "password" );

--- a/core/src/test/java/org/pentaho/metaverse/listener/MetaversePluginLifecycleListenerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/listener/MetaversePluginLifecycleListenerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,12 +27,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.metaverse.listener.MetaversePluginLifecycleListener;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class MetaversePluginLifecycleListenerTest {
 
   @Mock private Graph mockGraph;
@@ -55,8 +57,8 @@ public class MetaversePluginLifecycleListenerTest {
   @Test
   public void testUnload_NullGraph() throws Exception {
     MetaversePluginLifecycleListener spyListener = spy( metaversePluginLifecycleListener );
-    when( spyListener.getGraph() ).thenReturn( null );
-    metaversePluginLifecycleListener.unLoaded();
+    doReturn( null ).when( spyListener ).getGraph();
+    spyListener.unLoaded();
 
     verify( mockGraph, times ( 0 ) ).shutdown();
   }

--- a/core/src/test/java/org/pentaho/metaverse/locator/DIRepositoryLocatorTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/locator/DIRepositoryLocatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.JobMeta;
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.when;
  *
  * @author jdixon
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DIRepositoryLocatorTest implements IDocumentListener {
 
   private List<IDocumentEvent> events;

--- a/core/src/test/java/org/pentaho/metaverse/locator/FileSystemLocatorTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/locator/FileSystemLocatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.metaverse.api.IDocumentEvent;
@@ -46,7 +46,10 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -55,7 +58,7 @@ import static org.mockito.Mockito.spy;
  * @author jdixon
  */
 @SuppressWarnings( { "all" } )
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class FileSystemLocatorTest implements IDocumentListener {
 
   private List<IDocumentEvent> events;

--- a/core/src/test/java/org/pentaho/metaverse/locator/LocatorRunnerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/locator/LocatorRunnerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,24 +28,30 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.metaverse.api.IDocument;
 import org.pentaho.metaverse.api.IDocumentEvent;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
 import org.pentaho.metaverse.api.IMetaverseObjectFactory;
 import org.pentaho.metaverse.api.INamespace;
-import org.pentaho.metaverse.api.MetaverseAnalyzerException;
 import org.pentaho.metaverse.api.MetaverseDocument;
 import org.pentaho.metaverse.api.MetaverseException;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class LocatorRunnerTest {
 
   @Mock
@@ -65,9 +71,9 @@ public class LocatorRunnerTest {
 
   @Before
   public void setUp() throws Exception {
-    when( baseLocator.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
-    when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( metaverseObjectFactory );
-    when( metaverseObjectFactory.createDocumentObject() ).thenReturn( new MetaverseDocument() );
+    lenient().when( baseLocator.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
+    lenient().when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( metaverseObjectFactory );
+    lenient().when( metaverseObjectFactory.createDocumentObject() ).thenReturn( new MetaverseDocument() );
   }
 
   LocatorRunner<String> stringLocatorRunner = new LocatorRunner<String>() {
@@ -121,7 +127,6 @@ public class LocatorRunnerTest {
 
   @Test
   public void testProcessFileStopping() throws Exception {
-    when( baseLocator.getMetaverseBuilder() ).thenThrow( MetaverseAnalyzerException.class );
     stringLocatorRunner.setLocator( baseLocator );
     stringLocatorRunner.stop();
     stringLocatorRunner.processFile( namespace, null, null, null );
@@ -129,7 +134,6 @@ public class LocatorRunnerTest {
 
   @Test
   public void testProcessFileNoExtension() throws Exception {
-    when( baseLocator.getMetaverseBuilder() ).thenThrow( MetaverseAnalyzerException.class );
     stringLocatorRunner.setLocator( baseLocator );
     stringLocatorRunner.processFile( namespace, "", null, null );
   }

--- a/core/src/test/java/org/pentaho/metaverse/locator/LocatorTestUtils.java
+++ b/core/src/test/java/org/pentaho/metaverse/locator/LocatorTestUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -45,7 +45,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/org/pentaho/metaverse/locator/RepositoryLocatorTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/locator/RepositoryLocatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.metaverse.api.IDocumentListener;
 import org.pentaho.metaverse.api.IMetaverseBuilder;
 import org.pentaho.metaverse.api.IMetaverseNode;
@@ -46,10 +46,13 @@ import java.util.ArrayList;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 
 public class RepositoryLocatorTest {
 
@@ -98,9 +101,9 @@ public class RepositoryLocatorTest {
     };
     loc.setMetaverseBuilder( metaverseBuilder );
     baseLocator = spy( loc );
-    when( baseLocator.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
-    when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( metaverseObjectFactory );
-    when( metaverseObjectFactory.createDocumentObject() ).thenReturn( new MetaverseDocument() );
+    lenient().when( baseLocator.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
+    lenient().when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( metaverseObjectFactory );
+    lenient().when( metaverseObjectFactory.createDocumentObject() ).thenReturn( new MetaverseDocument() );
   }
 
   @Test
@@ -140,7 +143,7 @@ public class RepositoryLocatorTest {
 
   @Test
   public void testStartScan() throws Exception {
-    when( baseLocator.getUnifiedRepository( any( IPentahoSession.class ) ) ).thenReturn( repository );
+    when( baseLocator.getUnifiedRepository( any() ) ).thenReturn( repository );
     when( repository.getTree( any( RepositoryRequest.class ) ) ).thenReturn( mock( RepositoryFileTree.class ) );
 
     baseLocator.startScan();
@@ -148,7 +151,7 @@ public class RepositoryLocatorTest {
 
   @Test( expected = MetaverseLocatorException.class )
   public void testStartScanAlreadyExecuting() throws Exception {
-    when( baseLocator.getUnifiedRepository( any( IPentahoSession.class ) ) ).thenReturn( repository );
+    when( baseLocator.getUnifiedRepository( any() ) ).thenReturn( repository );
     when( repository.getTree( any( RepositoryRequest.class ) ) ).thenReturn( mock( RepositoryFileTree.class ) );
     baseLocator.futureTask = futureTask;
     baseLocator.startScan();
@@ -156,7 +159,7 @@ public class RepositoryLocatorTest {
 
   @Test( expected = MetaverseLocatorException.class )
   public void testStartScanException() throws Exception {
-    when( baseLocator.getUnifiedRepository( any( IPentahoSession.class ) ) ).thenThrow( Exception.class );
+    when( baseLocator.getUnifiedRepository( any() ) ).thenThrow( Exception.class );
     baseLocator.startScan();
   }
 }

--- a/core/src/test/java/org/pentaho/metaverse/testutils/MetaverseTestUtils.java
+++ b/core/src/test/java/org/pentaho/metaverse/testutils/MetaverseTestUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,8 +29,8 @@ import org.pentaho.metaverse.api.MetaverseObjectFactory;
 import org.pentaho.metaverse.api.analyzer.kettle.jobentry.IJobEntryExternalResourceConsumerProvider;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepExternalResourceConsumerProvider;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author mburgess
@@ -46,9 +46,9 @@ public class MetaverseTestUtils {
   public static IDocumentController getDocumentController() {
     IDocumentController documentController = mock( IDocumentController.class );
     IMetaverseBuilder metaverseBuilder = mock( IMetaverseBuilder.class );
-    when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( getMetaverseObjectFactory() );
-    when( documentController.getMetaverseObjectFactory() ).thenReturn( getMetaverseObjectFactory() );
-    when( documentController.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
+    lenient().when( metaverseBuilder.getMetaverseObjectFactory() ).thenReturn( getMetaverseObjectFactory() );
+    lenient().when( documentController.getMetaverseObjectFactory() ).thenReturn( getMetaverseObjectFactory() );
+    lenient().when( documentController.getMetaverseBuilder() ).thenReturn( metaverseBuilder );
     return documentController;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,11 @@
   <properties>
     <dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>
     <dependency.pentaho.pentaho-platform-repository.version>${project.version}</dependency.pentaho.pentaho-platform-repository.version>
-    <dependency.junit.junit.version>4.11</dependency.junit.junit.version>
+    <dependency.junit.junit.version>4.13.2</dependency.junit.junit.version>
     <dependency.com.tinkerpop.blueprints.version>2.6.0</dependency.com.tinkerpop.blueprints.version>
     <dependency.commons-configuration.commons-configuration.version>1.9</dependency.commons-configuration.commons-configuration.version>
     <dependency.commons-collections.commons-collections.version>3.2.1</dependency.commons-collections.commons-collections.version>
-    <dependency.org.mockito.mockito-all.version>1.10.19</dependency.org.mockito.mockito-all.version>
-    <dependency.org.powermock.version>1.7.4</dependency.org.powermock.version>
+    <dependency.org.mockito.mockito-core.version>5.10.0</dependency.org.mockito.mockito-core.version>
     <dependency.pentaho-kettle.kettle-core.version>${project.version}</dependency.pentaho-kettle.kettle-core.version>
     <dependency.pentaho.pentaho-platform-core.version>${project.version}</dependency.pentaho.pentaho-platform-core.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -37,8 +37,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${dependency.org.mockito.mockito-all.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.org.mockito.mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sample/src/test/java/org/pentaho/metaverse/sample/DummyStepAnalyzerTest.java
+++ b/sample/src/test/java/org/pentaho/metaverse/sample/DummyStepAnalyzerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,18 +26,20 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.steps.dummytrans.DummyTransMeta;
 import org.pentaho.metaverse.api.IMetaverseNode;
 
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DummyStepAnalyzerTest {
 
   DummyStepAnalyzer analyzer;

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -20,6 +20,9 @@
     <enunciate.version>1.27</enunciate.version>
     <maven-pmd-plugin.version>3.2</maven-pmd-plugin.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
+    <maven-surefire-plugin.argLine>
+      --add-opens=java.base/java.lang=ALL-UNNAMED
+    </maven-surefire-plugin.argLine>
   </properties>
   <dependencies>
     <!-- we are excluding javax.ws.rs:jsr311-api bellow,
@@ -114,8 +117,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${dependency.org.mockito.mockito-all.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.org.mockito.mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/web/src/test/java/org/pentaho/metaverse/service/AnalyzerInfoServiceTest.java
+++ b/web/src/test/java/org/pentaho/metaverse/service/AnalyzerInfoServiceTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.metaverse.analyzer.kettle.jobentry.transjob.TransJobEntryAnalyzer;
 import org.pentaho.metaverse.analyzer.kettle.step.mergejoin.MergeJoinStepAnalyzer;
 import org.pentaho.metaverse.analyzer.kettle.step.stringscut.StringsCutStepAnalyzer;
@@ -36,14 +36,15 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzer;
 import org.pentaho.metaverse.api.analyzer.kettle.step.IStepAnalyzerProvider;
 
 import javax.ws.rs.core.Response;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class AnalyzerInfoServiceTest {
 
   AnalyzerInfoService service;

--- a/web/src/test/java/org/pentaho/metaverse/service/LineageStreamingOutputTest.java
+++ b/web/src/test/java/org/pentaho/metaverse/service/LineageStreamingOutputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,17 +26,17 @@ package org.pentaho.metaverse.service;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.metaverse.api.ILineageCollector;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class LineageStreamingOutputTest {
 
   @Mock


### PR DESCRIPTION
~This PR \*should\* be on top of the 3/8 unit test fix commits. I'm not sure if we just want to deal with some extra merge commits when we merge in the feature branch or if we should pull those changes into the JDK17 branch and re-open this PR -- seems like a similar effort either way since there's unlikely to be much more activity in this repo before the feature branch merge anyway.~

Another thing to note: AnnotationDrivenStepMetaAnalyzerTest has been mostly commented out since it was broken by the Log4J vulnerability fix. I left it as is for now because the diffs on this PR were big enough already, but we should revisit that after these changes are in.