### PR TITLE
[TEST] Fixing testWriteRepoAttributes method argument matchers

### DIFF
--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobEntryBaseJsonSerializerTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/JobEntryBaseJsonSerializerTest.java
@@ -90,8 +90,8 @@ public class JobEntryBaseJsonSerializerTest {
   @Test
   public void testWriteRepoAttributes() throws Exception {
     serializer.writeRepoAttributes( meta, json );
-    verify( json, atLeastOnce() ).writeObjectField( JobEntryBaseJsonSerializer.JSON_PROPERTY_FIELDS, anyList() );
-    verify( json, atLeastOnce() ).writeObjectField( JobEntryBaseJsonSerializer.JSON_PROPERTY_ATTRIBUTES, anyMap() );
+    verify( json, atLeastOnce() ).writeObjectField( eq( JobEntryBaseJsonSerializer.JSON_PROPERTY_FIELDS ), anyList() );
+    verify( json, atLeastOnce() ).writeObjectField( eq( JobEntryBaseJsonSerializer.JSON_PROPERTY_ATTRIBUTES ), anyMap() );
   }
 
   @Test


### PR DESCRIPTION
Backporting the change, already in master under [pentaho-metaverse#686](https://github.com/pentaho/pentaho-metaverse/pull/686), that fixes the failing 'org.pentaho.metaverse.impl.model.kettle.json.JobEntryBaseJsonSerializerTest.testWriteRepoAttributes' unit test:

![image](https://github.com/pentaho/pentaho-metaverse/assets/6816863/b93e951b-984f-44a9-8943-12ebfd63c509)

@renato-s @andreramos89 @befc @joana-fb @miguelappleton 
