### PR TITLE
[SP-6635] Backport of PPP-4895 - Vulnerable Component: Jettison

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -67,6 +67,12 @@
       <artifactId>blueprints-core</artifactId>
       <version>${dependency.com.tinkerpop.blueprints.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.sf.flexjson</groupId>

--- a/assemblies/plugin/src/assembly/assembly.xml
+++ b/assemblies/plugin/src/assembly/assembly.xml
@@ -30,6 +30,7 @@
         <exclude>org.pentaho.*</exclude>
         <exclude>com.tinkerpop.blueprints:*</exclude>
         <exclude>pentaho:pentaho-metaverse-core:jar</exclude>
+        <exclude>org.codehaus.jettison:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,12 @@
       <artifactId>blueprints-core</artifactId>
       <version>${dependency.com.tinkerpop.blueprints.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-configuration</groupId>


### PR DESCRIPTION
- [PPP-4895] Exclude jettison in metaverse-plugin assembly.xml
- [PPP-4895] Exclude jettison in pentaho-metaverse plugin

[PPP-4895]: https://hv-eng.atlassian.net/browse/PPP-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPP-4895]: https://hv-eng.atlassian.net/browse/PPP-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ