### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ExternalResourceCache.java
@@ -15,7 +15,6 @@ package org.pentaho.metaverse.api.analyzer.kettle;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -30,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -157,7 +157,7 @@ public class ExternalResourceCache {
    */
   public abstract class Resources<V> {
 
-    protected Set<V> internal = new ConcurrentHashSet();
+    protected Set<V> internal = ConcurrentHashMap.newKeySet();
 
     public void add( final V value ) {
       internal.add( value );


### PR DESCRIPTION
This pull request updates the `ExternalResourceCache` class in the `api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle` package to replace the use of `ConcurrentHashSet` with `ConcurrentHashMap.newKeySet()`. This change improves compatibility and aligns with modern Java practices.

Key changes:

### Dependency Updates:
* Removed the import for `org.eclipse.jetty.util.ConcurrentHashSet` and added an import for `java.util.concurrent.ConcurrentHashMap`. [[1]](diffhunk://#diff-62b1ad59a3b38a32fa67defa4a37c022be8d0680054bbb550a2e694ddacbcdfeL18) [[2]](diffhunk://#diff-62b1ad59a3b38a32fa67defa4a37c022be8d0680054bbb550a2e694ddacbcdfeR32)

### Code Refactoring:
* Replaced the `ConcurrentHashSet` with `ConcurrentHashMap.newKeySet()` in the `Resources<V>` class for the `internal` field, ensuring better compatibility with standard Java libraries.