### PR TITLE
fix[PPP-6483]: Remove stale flexjson version property from root pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -78,12 +78,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${dependency.net.sf.flexjson.flexjson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
@@ -241,7 +241,9 @@ public class ComponentDerivationRecord {
     try {
       return OBJECT_MAPPER.writeValueAsString( root );
     } catch ( JsonProcessingException e ) {
-      throw new IllegalStateException( "Unable to serialize component derivation record", e );
+      // Return a safe fallback string instead of throwing, to avoid surprising failures
+      // in logging/debugging code paths that invoke toString()
+      return getClass().getSimpleName() + "@" + Integer.toHexString( hashCode() );
     }
   }
 }

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
@@ -220,13 +220,13 @@ public class ComponentDerivationRecord {
     ObjectNode root = OBJECT_MAPPER.createObjectNode();
 
     if ( operations != null ) {
-      for ( ChangeType changeType : ChangeType.values() ) {
-        List<IOperation> operationsForType = operations.get( changeType );
+      for ( ChangeType ct : ChangeType.values() ) {
+        List<IOperation> operationsForType = operations.get( ct );
         if ( operationsForType == null ) {
           continue;
         }
 
-        ArrayNode operationArray = root.putArray( changeType.toString() );
+        ArrayNode operationArray = root.putArray( ct.toString() );
         for ( IOperation operation : operationsForType ) {
           ObjectNode operationNode = operationArray.addObject();
           operationNode.put( "category", operation.getCategory() );

--- a/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
+++ b/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/ComponentDerivationRecord.java
@@ -13,8 +13,11 @@
 
 package org.pentaho.metaverse.api.analyzer.kettle;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.StepField;
 import org.pentaho.metaverse.api.model.IInfo;
@@ -31,6 +34,8 @@ import java.util.List;
  */
 @JsonTypeInfo( use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = IInfo.JSON_PROPERTY_CLASS )
 public class ComponentDerivationRecord {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   protected StepField originalField;
   protected StepField changedField;
@@ -212,6 +217,31 @@ public class ComponentDerivationRecord {
 
   @Override
   public String toString() {
-    return new JSONSerializer().include( "*" ).serialize( operations );
+    ObjectNode root = OBJECT_MAPPER.createObjectNode();
+
+    if ( operations != null ) {
+      for ( ChangeType changeType : ChangeType.values() ) {
+        List<IOperation> operationsForType = operations.get( changeType );
+        if ( operationsForType == null ) {
+          continue;
+        }
+
+        ArrayNode operationArray = root.putArray( changeType.toString() );
+        for ( IOperation operation : operationsForType ) {
+          ObjectNode operationNode = operationArray.addObject();
+          operationNode.put( "category", operation.getCategory() );
+          operationNode.put( "class", operation.getClass().getName() );
+          operationNode.put( "description", operation.getDescription() );
+          operationNode.put( "name", operation.getName() );
+          operationNode.put( "type", operation.getType() == null ? null : operation.getType().name() );
+        }
+      }
+    }
+
+    try {
+      return OBJECT_MAPPER.writeValueAsString( root );
+    } catch ( JsonProcessingException e ) {
+      throw new IllegalStateException( "Unable to serialize component derivation record", e );
+    }
   }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,12 +147,6 @@
       <version>${gremlin-java.version}</version>
     </dependency>
     <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${dependency.net.sf.flexjson.flexjson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
@@ -183,7 +183,7 @@ public class MetaverseUtil {
 
   public static Operations convertOperationsStringToMap( String operations ) {
     Operations resultOps = null;
-    if ( !Const.isEmpty( operations ) ) {
+    if ( operations != null && !operations.isEmpty() ) {
       try {
         JsonNode root = OBJECT_MAPPER.readTree( operations );
         resultOps = new Operations();
@@ -197,34 +197,7 @@ public class MetaverseUtil {
               continue;
             }
 
-            List<IOperation> typedOperations = new ArrayList<IOperation>();
-            for ( JsonNode operationNode : entry.getValue() ) {
-              JsonNode nameNode = operationNode.get( "name" );
-              String name = nameNode == null || nameNode.isNull() ? null : nameNode.asText();
-              JsonNode descNode = operationNode.get( "description" );
-              String description = descNode == null || descNode.isNull() ? null : descNode.asText();
-              JsonNode catNode = operationNode.get( "category" );
-              String category = catNode == null || catNode.isNull() ? null : catNode.asText();
-              JsonNode typeNode = operationNode.get( "type" );
-              String typeValue = typeNode == null || typeNode.isNull() ? null : typeNode.asText();
-
-              ChangeType operationType = changeType;  // default to the map key
-              if ( !Const.isEmpty( typeValue ) ) {
-                try {
-                  operationType = ChangeType.valueOf( typeValue );
-                } catch ( IllegalArgumentException ignored ) {
-                  // keep default
-                }
-              }
-
-              Operation operation = new Operation( name, description );
-              operation.setCategory( category );
-              operation.setType( operationType );
-
-              typedOperations.add( operation );
-            }
-
-            resultOps.put( changeType, typedOperations );
+            processOperationNodeList( entry.getValue(), changeType, resultOps );
           }
         }
       } catch ( Exception e ) {
@@ -232,6 +205,46 @@ public class MetaverseUtil {
       }
     }
     return resultOps;
+  }
+
+  private static void processOperationNodeList( Iterable<JsonNode> operationNodes, ChangeType changeType,
+      Operations resultOps ) {
+    List<IOperation> typedOperations = new ArrayList<>();
+    for ( JsonNode operationNode : operationNodes ) {
+      IOperation operation = parseOperationNode( operationNode, changeType );
+      typedOperations.add( operation );
+    }
+    resultOps.put( changeType, typedOperations );
+  }
+
+  private static IOperation parseOperationNode( JsonNode operationNode, ChangeType changeType ) {
+    String name = extractStringValue( operationNode, "name" );
+    String description = extractStringValue( operationNode, "description" );
+    String category = extractStringValue( operationNode, "category" );
+    String typeValue = extractStringValue( operationNode, "type" );
+
+    ChangeType operationType = changeType;  // default to the map key
+    if ( typeValue != null && !typeValue.isEmpty() ) {
+      operationType = parseChangeType( typeValue, changeType );
+    }
+
+    Operation operation = new Operation( name, description );
+    operation.setCategory( category );
+    operation.setType( operationType );
+    return operation;
+  }
+
+  private static String extractStringValue( JsonNode node, String fieldName ) {
+    JsonNode fieldNode = node.get( fieldName );
+    return fieldNode == null || fieldNode.isNull() ? null : fieldNode.asText();
+  }
+
+  private static ChangeType parseChangeType( String typeValue, ChangeType defaultType ) {
+    try {
+      return ChangeType.valueOf( typeValue );
+    } catch ( IllegalArgumentException ignored ) {
+      return defaultType;
+    }
   }
 
   public static Runnable getAnalyzerRunner( final IDocumentAnalyzer analyzer, final IDocument document ) {

--- a/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
@@ -13,11 +13,12 @@
 
 package org.pentaho.metaverse.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
-import flexjson.JSONDeserializer;
 import org.pentaho.di.core.Const;
 import org.pentaho.dictionary.DictionaryConst;
 import org.pentaho.dictionary.DictionaryHelper;
@@ -43,6 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -53,6 +56,7 @@ import java.util.concurrent.Future;
 public class MetaverseUtil {
 
   private static final Logger log = LoggerFactory.getLogger( MetaverseUtil.class );
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public static final String MESSAGE_PREFIX_NODETYPE = "USER.nodetype.";
   public static final String MESSAGE_PREFIX_LINKTYPE = "USER.linktype.";
@@ -181,17 +185,45 @@ public class MetaverseUtil {
     Operations resultOps = null;
     if ( !Const.isEmpty( operations ) ) {
       try {
-        Map<String, List<IOperation>> rawOpsMap = new JSONDeserializer<Map<String, List<IOperation>>>().
-          use( "values.values", Operation.class ).
-          deserialize( operations );
+        JsonNode root = OBJECT_MAPPER.readTree( operations );
         resultOps = new Operations();
-        for ( String key : rawOpsMap.keySet() ) {
-          resultOps.put( ChangeType.forValue( key ), rawOpsMap.get( key ) );
+
+        if ( root != null && root.isObject() ) {
+          Iterator<Map.Entry<String, JsonNode>> fields = root.fields();
+          while ( fields.hasNext() ) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            ChangeType changeType = ChangeType.forValue( entry.getKey() );
+            if ( changeType == null || !entry.getValue().isArray() ) {
+              continue;
+            }
+
+            List<IOperation> typedOperations = new ArrayList<IOperation>();
+            for ( JsonNode operationNode : entry.getValue() ) {
+              String name = operationNode.path( "name" ).isMissingNode() ? null : operationNode.path( "name" ).asText();
+              String description = operationNode.path( "description" ).isMissingNode() ? null : operationNode.path( "description" ).asText();
+              String category = operationNode.path( "category" ).isMissingNode() ? null : operationNode.path( "category" ).asText();
+              String typeValue = operationNode.path( "type" ).isMissingNode() ? null : operationNode.path( "type" ).asText();
+
+              Operation operation = new Operation( name, description );
+              operation.setCategory( category );
+
+              if ( !Const.isEmpty( typeValue ) ) {
+                try {
+                  operation.setType( ChangeType.valueOf( typeValue ) );
+                } catch ( IllegalArgumentException ignored ) {
+                  operation.setType( null );
+                }
+              }
+
+              typedOperations.add( operation );
+            }
+
+            resultOps.put( changeType, typedOperations );
+          }
         }
       } catch ( Exception e ) {
         resultOps = null;
       }
-      //return new JSONDeserializer<Operations>().use(null, Operations.class).deserialize( operations );
     }
     return resultOps;
   }

--- a/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
+++ b/core/src/main/java/org/pentaho/metaverse/util/MetaverseUtil.java
@@ -199,21 +199,27 @@ public class MetaverseUtil {
 
             List<IOperation> typedOperations = new ArrayList<IOperation>();
             for ( JsonNode operationNode : entry.getValue() ) {
-              String name = operationNode.path( "name" ).isMissingNode() ? null : operationNode.path( "name" ).asText();
-              String description = operationNode.path( "description" ).isMissingNode() ? null : operationNode.path( "description" ).asText();
-              String category = operationNode.path( "category" ).isMissingNode() ? null : operationNode.path( "category" ).asText();
-              String typeValue = operationNode.path( "type" ).isMissingNode() ? null : operationNode.path( "type" ).asText();
+              JsonNode nameNode = operationNode.get( "name" );
+              String name = nameNode == null || nameNode.isNull() ? null : nameNode.asText();
+              JsonNode descNode = operationNode.get( "description" );
+              String description = descNode == null || descNode.isNull() ? null : descNode.asText();
+              JsonNode catNode = operationNode.get( "category" );
+              String category = catNode == null || catNode.isNull() ? null : catNode.asText();
+              JsonNode typeNode = operationNode.get( "type" );
+              String typeValue = typeNode == null || typeNode.isNull() ? null : typeNode.asText();
+
+              ChangeType operationType = changeType;  // default to the map key
+              if ( !Const.isEmpty( typeValue ) ) {
+                try {
+                  operationType = ChangeType.valueOf( typeValue );
+                } catch ( IllegalArgumentException ignored ) {
+                  // keep default
+                }
+              }
 
               Operation operation = new Operation( name, description );
               operation.setCategory( category );
-
-              if ( !Const.isEmpty( typeValue ) ) {
-                try {
-                  operation.setType( ChangeType.valueOf( typeValue ) );
-                } catch ( IllegalArgumentException ignored ) {
-                  operation.setType( null );
-                }
-              }
+              operation.setType( operationType );
 
               typedOperations.add( operation );
             }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <url>https://github.com/pentaho/${project.artifactId}</url>
   </scm>
   <properties>
-    <dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>
     <dependency.pentaho.pentaho-platform-repository.version>${project.version}</dependency.pentaho.pentaho-platform-repository.version>
     <dependency.junit.junit.version>4.13.2</dependency.junit.junit.version>
     <dependency.com.tinkerpop.blueprints.version>2.6.0</dependency.com.tinkerpop.blueprints.version>


### PR DESCRIPTION
## Summary
Removes the orphaned `dependency.net.sf.flexjson.flexjson.version` property from the root `pom.xml`.

## Changes
- `pom.xml`: Remove `<dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>` property

## Context
The property is no longer referenced by any module in this repository. Cleanup as part of the full flexjson removal (PPP-6483).