### PR TITLE
fix[PPP-6483]: Remove stale flexjson version property from root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <url>https://github.com/pentaho/${project.artifactId}</url>
   </scm>
   <properties>
-    <dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>
     <dependency.pentaho.pentaho-platform-repository.version>${project.version}</dependency.pentaho.pentaho-platform-repository.version>
     <dependency.junit.junit.version>4.13.2</dependency.junit.junit.version>
     <dependency.org.apache.tinkerpop.version>3.7.3</dependency.org.apache.tinkerpop.version>


### PR DESCRIPTION
## Summary
Removes the orphaned `dependency.net.sf.flexjson.flexjson.version` property from the root `pom.xml`.

## Changes
- `pom.xml`: Remove `<dependency.net.sf.flexjson.flexjson.version>2.1</dependency.net.sf.flexjson.flexjson.version>` property

## Context
The Jackson migration for this repo was completed in #728. This property is no longer referenced by any module. Cleanup as part of the full flexjson removal (PPP-6483).