### PR TITLE
fix[BACKLOG-50609]: Restore strict Jackson unknown-property handling in KettleObjectMapper

### DIFF
--- a/core/src/main/java/org/pentaho/metaverse/impl/model/kettle/json/KettleObjectMapper.java
+++ b/core/src/main/java/org/pentaho/metaverse/impl/model/kettle/json/KettleObjectMapper.java
@@ -15,7 +15,6 @@ package org.pentaho.metaverse.impl.model.kettle.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -65,7 +64,6 @@ public class KettleObjectMapper {
 
   private void doInit( List<StdSerializer> serializers, List<StdDeserializer> deserializers ) {
     mapper = new ObjectMapper();
-    mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
     mapper.enable( SerializationFeature.INDENT_OUTPUT );
     mapper.disable( SerializationFeature.FAIL_ON_EMPTY_BEANS );
     mapper.enable( SerializationFeature.WRAP_EXCEPTIONS );

--- a/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/KettleObjectMapperTest.java
+++ b/core/src/test/java/org/pentaho/metaverse/impl/model/kettle/json/KettleObjectMapperTest.java
@@ -13,6 +13,7 @@
 
 package org.pentaho.metaverse.impl.model.kettle.json;
 
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.junit.Before;
@@ -84,5 +85,15 @@ public class KettleObjectMapperTest {
     serializers.add( serializer );
     mapper = new KettleObjectMapper( serializers, null );
     mapper.writeValueAsString( new TransMeta() );
+  }
+
+  @Test( expected = UnrecognizedPropertyException.class )
+  public void testReadValueRejectsUnknownProperties() throws Exception {
+    mapper = new KettleObjectMapper( null, null );
+    mapper.readValue( "{\"known\":\"value\",\"unexpected\":true}", TestModel.class );
+  }
+
+  public static class TestModel {
+    public String known;
   }
 }


### PR DESCRIPTION
### Summary
Restore Jackson's default strict deserialization in `KettleObjectMapper` by
removing the `FAIL_ON_UNKNOWN_PROPERTIES` override added during the Flexjson→Jackson
migration (PPP-6483). These payloads are internal, so failing fast on unexpected
fields surfaces real issues instead of silently dropping data.

The custom `TransMetaJsonDeserializer` reads its own schema (`@class`, name,
steps, hops, etc.) node-by-node, so it is unaffected by the stricter setting.

### Changes
- `KettleObjectMapper.doInit()` — remove `disable(FAIL_ON_UNKNOWN_PROPERTIES)`
- Add a regression test asserting unknown properties are now rejected

### Testing
`mvn -pl core test` (focused): `KettleObjectMapperTest` + `TransMetaJsonDeserializerTest` = 11 tests pass.
