### PR TITLE
[PPP-7075] Remove unused org.apache.ivy:ivy from the metaverse plugin (CVE-2026-26032)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -151,6 +151,10 @@
           <groupId>jline</groupId>
           <artifactId>jline</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes the `pdia-master` security violation for **CVE-2026-26032** (`org.apache.ivy:ivy:2.5.3`, Medium, CVSS 5.4, CWE-22) — Jira **PPP-7075**.

## Why Ivy is here at all

It is *not* declared anywhere in this repo, or anywhere else in the `pentaho` org's Maven builds. It arrives on exactly one path:

```
pentaho:metaverse-plugin
  \- pentaho:pentaho-metaverse-core
       \- org.apache.tinkerpop:gremlin-groovy:3.7.6
            \- org.apache.ivy:ivy:2.5.3 (compile)
```

…and lands in `metaverse-plugin/lib/ivy-2.5.3.jar`, which is what Xray flags in all six impacted artifacts (`pdi-ce`, `pdi-ee-client`, `pentaho-server-{ce,ee}`, `pentaho-server-manual-{ce,ee}`).

**Nothing uses it.** Evidence rather than assumption:

- A bytecode scan of every jar shipped in `metaverse-plugin/lib` finds only three referencing `org/apache/ivy`: `gremlin-groovy`'s `DependencyGrabber`, Groovy's own `groovy.grape.GrapeIvy`, and `groovy-console`'s `ConsoleIvyPlugin`. All three are the Grape / `@Grab` dynamic-dependency downloader, reachable only from an interactive Gremlin/Groovy console.
- `api/`, `core/` and `web/` main sources contain **zero** references to `groovy`, `gremlin.groovy`, `ScriptEngine` or `Grape`. The plugin ships no Groovy scripts and evaluates none.
- The only Groovy in the repo is the integration-test fixtures (`core/src/it/resources/*.groovy`), driven by an `exec-maven-plugin` execution that carries its **own plugin-scope** `gremlin-groovy` — unaffected by this change.

## The change

One exclusion added to the existing `gremlin-groovy` dependency in `core/pom.xml` (which already excludes `commons-lang3` and `jline`). This is the highest declaring point — there is no version property and no leaf override anywhere.

Removal was chosen over the advisory's recommended `2.5.3 -> 2.6.0` bump because it deletes the vulnerable `PackagerResolver` code from the product instead of shipping a patched copy of a library nothing calls, and it ends the recurring Ivy CVE stream on this path. If a reviewer knows of a Grape/`@Grab` consumer I could not find, the fallback is a straight bump to 2.6.0 — say so and I will switch.

## Proof

| check | before (vulnerable baseline) | after |
|---|---|---|
| `mvn -pl core -DskipITs=true test` | **786 tests, 0 failures** (green *before* any edit) | **786 tests, 0 failures** |
| `mvn -pl assemblies/plugin -am dependency:tree` | `org.apache.ivy` on **6** lines, all `ivy:2.5.3:compile` | **0 occurrences** |
| jars in shipped `metaverse-plugin/lib/` | 27, including `ivy-2.5.3.jar` | 26 — **removed: `ivy-2.5.3.jar`; added: none** |

Full reactor `mvn package -DskipTests` is green. The packaging diff is the security assertion: exactly one jar leaves the artifact and nothing else moves.

Advisory: NVD `CVE-2026-26032`, CNA `security@apache.org`, affected `2.0.0` → `2.6.0` (exclusive). Xray `summary/component` reports `ivy:2.6.0` clean and `ivy:2.5.3` carrying `XRAY-1027953`.

## Follow-up worth a product decision (not in this PR)

The whole `gremlin-groovy` compile dependency looks unused at runtime by the same evidence — dropping it would also remove the eight `groovy-*` jars, `javaparser-core`, `jbcrypt` and `caffeine 2.3.1` from the shipped plugin. That is a larger blast radius than a CVE fix should carry, so it is left for the owners to judge.

Verification: CodeMedic does not treat this as cleared at merge — clearance is confirmed when a later `pdia-master` build is re-analyzed and CVE-2026-26032 is absent.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-376", "items": [{"cve": "CVE-2026-26032", "coordinate": "org.apache.ivy:ivy"}]} -->
