### PR TITLE
test(it): repair integration test suite and restore coverage [BACKLOG-43745]

### DIFF
--- a/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenStepMetaAnalyzerTest.java
+++ b/api/src/test/java/org/pentaho/metaverse/api/analyzer/kettle/annotations/AnnotationDrivenStepMetaAnalyzerTest.java
@@ -10,20 +10,41 @@
  * Change Date: 2030-06-15
  ******************************************************************************/
 
-
-
 package org.pentaho.metaverse.api.analyzer.kettle.annotations;
-// TODO: This test is hanging during QAT builds after the log4j upgrades were implemented. So the temporary solution
-//  is to comment it out completely and revisit a permanent solution in the future. The getTestStepMeta(...) method
-//  is needed for other tests so it is left oncommented along with any associated code.
-//import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.ObjectLocationSpecificationMethod;
+import org.pentaho.di.core.ProgressMonitorListener;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.injection.InjectionDeep;
+import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
 import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectory;
+import org.pentaho.di.trans.ISubTransAwareMeta;
 import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -31,297 +52,355 @@ import org.pentaho.di.trans.step.StepIOMeta;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.di.trans.steps.rowsfromresult.RowsFromResultMeta;
+import org.pentaho.di.trans.steps.writetolog.WriteToLogMeta;
+import org.pentaho.di.trans.streaming.common.BaseStreamStepMeta;
+import org.pentaho.dictionary.DictionaryHelper;
+import org.pentaho.dictionary.MetaverseTransientNode;
+import org.pentaho.metaverse.api.IComponentDescriptor;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.MetaverseAnalyzerException;
+import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
+import org.pentaho.metaverse.api.MetaverseObjectFactory;
+import org.pentaho.metaverse.api.StepField;
+import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
+import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
+import org.pentaho.metaverse.api.analyzer.kettle.step.SubtransAnalyzer;
+import org.pentaho.metaverse.api.model.BaseMetaverseBuilder;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singleton;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pentaho.dictionary.DictionaryConst.CATEGORY_DATASOURCE;
 import static org.pentaho.dictionary.DictionaryConst.CATEGORY_MESSAGE_QUEUE;
+import static org.pentaho.dictionary.DictionaryConst.CATEGORY_OTHER;
 import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS;
+import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS_CONCEPT;
 import static org.pentaho.dictionary.DictionaryConst.LINK_DEFINES;
+import static org.pentaho.dictionary.DictionaryConst.LINK_DEPENDENCYOF;
+import static org.pentaho.dictionary.DictionaryConst.LINK_INPUTS;
+import static org.pentaho.dictionary.DictionaryConst.LINK_PARENT_CONCEPT;
 import static org.pentaho.dictionary.DictionaryConst.LINK_READBY;
 import static org.pentaho.dictionary.DictionaryConst.LINK_WRITESTO;
+import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_EXTERNAL_CONNECTION;
+import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_TRANS_FIELD;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_NAME;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_TYPE;
+import static org.pentaho.metaverse.api.analyzer.kettle.annotations.AnnotationDrivenStepMetaAnalyzerTest.TestStepMeta.CONN_TYPE;
+import static org.pentaho.metaverse.api.analyzer.kettle.annotations.AnnotationDrivenStepMetaAnalyzerTest.TestStepMeta.TEST_TYPE;
+import static org.pentaho.metaverse.api.analyzer.kettle.annotations.Metaverse.FALSE;
+import static org.pentaho.metaverse.api.analyzer.kettle.annotations.Metaverse.SUBTRANS_INPUT;
 import static org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceStepAnalyzer.RESOURCE;
 
 
-//@RunWith ( PowerMockRunner.class )
-//@PowerMockIgnore( "jdk.internal.reflect.*" )
-//@PrepareForTest( KettleAnalyzerUtil.class )
 public class AnnotationDrivenStepMetaAnalyzerTest {
 
-//  private Map<String, String> typeCategoryMap = new HashMap<>();
-//  @Mock AnnotationDrivenStepMetaAnalyzer.EntityRegister entityRegister;
-//  private RowMeta inputRowMeta;
-//  private RowMeta outputRowMeta;
-//
-//  @Mock SubtransAnalyzer subtransAnalyzer;
-//
-//  private IMetaverseNode root = new MetaverseTransientNode( "rootNode" );
-//  private IMetaverseNode outputMessageNode = new MetaverseTransientNode( "messageOutputNode" );
-//  private IMetaverseNode outputTopicNode = new MetaverseTransientNode( "topicOutputNode" );
-//  private StepMetaInterface meta;
-//  private StepMetaInterface mappingMeta;
-//  private TestableAnnotationDrivenAnalyzer analyzer;
-//  private static IMetaverseNode subTransRoot = new MetaverseTransientNode( "subTransRootNode" );
-//
-//
-//  @BeforeClass
-//  public static void setupClass() throws Exception {
-//    KettleClientEnvironment.init();
-//    PluginRegistry.addPluginType( ValueMetaPluginType.getInstance() );
-//    PluginRegistry.init();
-//  }
-//
-//  @Before
-//  public void before() throws KettleException {
-//    inputRowMeta = new RowMeta();
-//    outputRowMeta = new RowMeta();
-//
-//    this.meta = getTestStepMeta( inputRowMeta );
-//    outputMessageNode.setName( "messageOutputNode" );
-//    outputMessageNode.setType( NODE_TYPE_TRANS_FIELD );
-//    outputTopicNode.setName( "topicOutputNode" );
-//    outputTopicNode.setType( NODE_TYPE_TRANS_FIELD );
-//
-//    analyzer = new TestableAnnotationDrivenAnalyzer( new TestStepMeta(), typeCategoryMap, entityRegister );
-//    //doNothing().when( subtransAnalyzer ).linkResultFieldToSubTrans( any(), any(), any(), any() );
-//  }
-//
-//
-//  @After
-//  public void after() {
-//    // the act of creating a metaverse builder registers entities.  Clear them out so
-//    // no state is carried forward.
-//    DictionaryHelper.clearEntityRegistry();
-//  }
-//
-//  @Test
-//  public void testGetUsedFields() {
-//    Set<StepField> usedFields = analyzer.getUsedFields( (BaseStepMeta) meta );
-//    assertThat( usedFields.size(), equalTo( 5 ) );
-//    List<String> usedList = usedFields.stream()
-//      .map( StepField::getFieldName )
-//      .sorted()
-//      .collect( Collectors.toList() );
-//    List<String> inputSteps = usedFields.stream()
-//      .map( StepField::getStepName )
-//      .sorted()
-//      .collect( Collectors.toList() );
-//    assertThat( usedList, equalTo( Arrays.asList( "messageField", "substitutedField",
-//      "usedField", "usedField1", "usedField2" ) ) );
-//    assertThat( inputSteps, equalTo( Arrays.asList( "Step1", "Step1", "Step1", "Step1", "Step1" ) ) );
-//  }
-//
-//  @Test
-//  public void testCustomAnalyze() throws MetaverseAnalyzerException {
-//    IMetaverseBuilder builder = getBuilder( root );
-//
-//    analyzer.loadInputAndOutputStreamFields( (BaseStepMeta) meta );
-//    analyzer.customAnalyze( (BaseStepMeta) meta, root );
-//    Graph graph = builder.getGraph();
-//
-//    List<Edge> edges = getEdgesWithLabel( graph, LINK_READBY );
-//
-//    assertThat( edges.size(), equalTo( 1 ) );
-//    Edge e = edges.get( 0 );
-//
-//    Vertex externalResourceV = e.getVertex( Direction.OUT );
-//    assertThat( externalResourceV.getProperty( "server" ), equalTo( "ServernameOrWhatever" ) );
-//    assertThat( externalResourceV.getProperty( "port" ), equalTo( "123" ) );
-//    assertThat( externalResourceV.getProperty( "isSsl" ), equalTo( "true" ) );
-//    assertThat( externalResourceV.getProperty( "name" ), equalTo( "ServernameOrWhatever" ) );
-//    assertThat( externalResourceV.getProperty( "type" ), equalTo( TEST_TYPE ) );
-//
-//    // nested properties in referenced class
-//    assertThat( externalResourceV.getProperty( "SUBPROP" ), equalTo( "subProp1" ) );
-//    assertThat( externalResourceV.getProperty( "subProp2" ), equalTo( "123" ) );
-//    assertThat( externalResourceV.getProperty( "method-property" ), equalTo( "blah" ) );
-//
-//    edges = getEdgesWithLabel( graph, LINK_DEPENDENCYOF );
-//
-//    assertThat( edges.size(), equalTo( 1 ) );
-//    e = edges.get( 0 );
-//
-//    externalResourceV = e.getVertex( Direction.OUT );
-//    assertThat( externalResourceV.getProperty( "dbaddress" ), equalTo( "127.0.0.1:3363" ) );
-//  }
-//
-//  @Test
-//  public void testCustomAnalyzeSubtrans() throws MetaverseAnalyzerException, KettleException {
-//    IMetaverseBuilder builder = getBuilder( root );
-//
-//    this.mappingMeta = getTestStepMappingMeta( inputRowMeta, outputRowMeta );
-//
-//    analyzer.loadInputAndOutputStreamFields( (BaseStepMeta) mappingMeta );
-//    analyzer.customAnalyze( (BaseStepMeta) mappingMeta, root );
-//    Graph graph = builder.getGraph();
-//
-//    List<Edge> edges = getEdgesWithLabel( graph, LINK_READBY );
-//
-//    assertThat( edges.size(), equalTo( 1 ) );
-//    Edge e = edges.get( 0 );
-//
-//    Vertex externalResourceV = e.getVertex( Direction.OUT );
-//    assertThat( externalResourceV.getProperty( "server" ), equalTo( "ServernameOrWhatever" ) );
-//    assertThat( externalResourceV.getProperty( "port" ), equalTo( "123" ) );
-//    assertThat( externalResourceV.getProperty( "isSsl" ), equalTo( "true" ) );
-//    assertThat( externalResourceV.getProperty( "name" ), equalTo( "ServernameOrWhatever" ) );
-//    assertThat( externalResourceV.getProperty( "type" ), equalTo( TEST_TYPE ) );
-//
-//    //verify server node "contains" the two input resources
-//    List<Vertex> resourceNodes = new ArrayList<>();
-//    externalResourceV.getVertices( Direction.OUT ).forEach( v -> resourceNodes.add( v ) );
-//    assertThat( resourceNodes.size(), equalTo( 3 ) );
-//    Vertex messageVertex = resourceNodes.stream().filter( v -> v.getProperty( PROPERTY_NAME ).equals( "message" ) ).findFirst().get();
-//    Vertex topicVertex = resourceNodes.stream().filter( v -> v.getProperty( PROPERTY_NAME ).equals( "topic" ) ).findFirst().get();
-//
-//    assertThat( messageVertex.getProperty( PROPERTY_TYPE ), equalTo( RESOURCE ) );
-//    assertThat( topicVertex.getProperty( PROPERTY_TYPE ), equalTo( RESOURCE ) );
-//
-//    // nested properties in referenced class
-//    assertThat( externalResourceV.getProperty( "SUBPROP" ), equalTo( "subProp1" ) );
-//    assertThat( externalResourceV.getProperty( "subProp2" ), equalTo( "123" ) );
-//
-//    edges = getEdgesWithLabel( graph, LINK_DEPENDENCYOF );
-//
-//    assertThat( edges.size(), equalTo( 1 ) );
-//    e = edges.get( 0 );
-//
-//    externalResourceV = e.getVertex( Direction.OUT );
-//    assertThat( externalResourceV.getProperty( "dbaddress" ), equalTo( "127.0.0.1:3363" ) );
-//
-//    doNothing().when( subtransAnalyzer ).linkUsedFieldToSubTrans( any(), any(), any(), any(), any() );
-//    doNothing().when( subtransAnalyzer ).linkResultFieldToSubTrans(
-//      any( IMetaverseNode.class ), any( TransMeta.class ), any( IMetaverseNode.class ),
-//      any( IComponentDescriptor.class ), any( String.class ) );
-//
-//    // verify subtrans analyzer was called on the expected nodes for input to subtrans
-//    ArgumentCaptor<IMetaverseNode> usedFieldsNodeCaptor = ArgumentCaptor.forClass( IMetaverseNode.class );
-//    ArgumentCaptor<IMetaverseNode> outputFieldsNodeCaptor = ArgumentCaptor.forClass( IMetaverseNode.class );
-//
-//    verify( subtransAnalyzer, times( 2 ) )
-//      .linkResultFieldToSubTrans( outputFieldsNodeCaptor.capture(), any(), any(), any(), any() );
-//    verify( subtransAnalyzer, times( 2 ) )
-//      .linkUsedFieldToSubTrans( usedFieldsNodeCaptor.capture(), any(), any(), any(), any() );
-//
-//    IMetaverseNode messageNode = usedFieldsNodeCaptor.getAllValues().stream()
-//      .filter( node -> node.getName().equals( "message" ) ).findFirst().get();
-//    IMetaverseNode topicNode = usedFieldsNodeCaptor.getAllValues().stream()
-//      .filter( node -> node.getName().equals( "topic" ) ).findFirst().get();
-//
-//    assertThat( usedFieldsNodeCaptor.getAllValues().size(), equalTo( 2 ) );
-//    assertThat( topicNode.getType(), equalTo( RESOURCE ) );
-//    assertThat( messageNode.getType(), equalTo( RESOURCE ) );
-//
-//    // verify subtrans analyzer was called on the expected nodes for output from subtrans
-//    IMetaverseNode messageOutputNode = outputFieldsNodeCaptor.getAllValues().stream()
-//      .filter( node -> node.getName().equals( "messageOutputNode" ) ).findFirst().get();
-//    IMetaverseNode topicOutputNode = outputFieldsNodeCaptor.getAllValues().stream()
-//      .filter( node -> node.getName().equals( "topicOutputNode" ) ).findFirst().get();
-//
-//    assertThat( outputFieldsNodeCaptor.getAllValues().size(), equalTo( 2 ) );
-//    assertThat( topicOutputNode.getType(), equalTo( NODE_TYPE_TRANS_FIELD ) );
-//    assertThat( messageOutputNode.getType(), equalTo( NODE_TYPE_TRANS_FIELD ) );
-//  }
-//
-//  @Test
-//  public void testResourceLinkage() throws MetaverseAnalyzerException {
-//    IMetaverseBuilder builder = getBuilder( root );
-//
-//    MetaverseComponentDescriptor descriptor = new MetaverseComponentDescriptor(
-//      "name", "type",
-//      root, analyzer.getDescriptor().getContext() );
-//
-//    analyzer.analyze( descriptor, (BaseStepMeta) meta );
-//    Graph graph = builder.getGraph();
-//
-//    List<Edge> edges = getEdgesWithLabel( graph, LINK_WRITESTO );
-//
-//    assertThat( edges.size(), equalTo( 2 ) );
-//    edges.sort( Comparator.comparing( e -> e.getVertex( Direction.IN ).getProperty( "name" ) ) );
-//    assertEdge( edges.get( 0 ), "Bora Bora", "name" );
-//    assertEdge( edges.get( 1 ), "message", "ServernameOrWhatever" );
-//
-//    edges = getEdgesWithLabel( graph, LINK_CONTAINS );
-//    assertThat( edges.size(), equalTo( 1 ) );
-//    assertEdge( edges.get( 0 ), "name", "private-field-value" );
-//
-//  }
-//
-//  private void assertEdge( Edge edge, String from, String to ) {
-//    assertThat( edge.getVertex( Direction.IN ).getProperty( "name" ), equalTo( from ) );
-//    assertThat( edge.getVertex( Direction.OUT ).getProperty( "name" ), equalTo( to ) );
-//  }
-//
-//  @Test
-//  public void testCategoryLinks() {
-//    assertThat( typeCategoryMap.get( CONN_TYPE ),
-//      equalTo( CATEGORY_DATASOURCE ) );
-//    assertThat( typeCategoryMap.get( TEST_TYPE ),
-//      equalTo( CATEGORY_OTHER ) );
-//  }
-//
-//  @Test
-//  public void testEntityLinks() {
-//
-//    verify( entityRegister ).registerEntityTypes( LINK_PARENT_CONCEPT, CONN_TYPE, NODE_TYPE_EXTERNAL_CONNECTION );
-//    verify( entityRegister ).registerEntityTypes( LINK_CONTAINS_CONCEPT, TEST_TYPE, CONN_TYPE );
-//    verify( entityRegister ).registerEntityTypes( LINK_PARENT_CONCEPT, TEST_TYPE, null );
-//  }
-//
-//  @Test
-//  public void testGetSupportedSteps() {
-//    assertThat( analyzer.getSupportedSteps(), equalTo( singleton( meta.getClass() ) ) );
-//  }
-//
-//
-//  private IMetaverseBuilder getBuilder( IMetaverseNode rootNode ) {
-//    IComponentDescriptor descriptor = new MetaverseComponentDescriptor( "descriptor", "someType", rootNode );
-//    analyzer.setDescriptor( descriptor );
-//    IMetaverseBuilder builder = new BaseMetaverseBuilder( new TinkerGraph() );
-//    analyzer.setMetaverseBuilder( builder );
-//    return builder;
-//  }
-//
-//  private List<Edge> getEdgesWithLabel( Graph graph, String edgeName ) {
-//    return StreamSupport.stream( graph.getEdges().spliterator(), false )
-//      .filter( edge -> edge.getLabel().equals( edgeName ) )
-//      .collect( Collectors.toList() );
-//  }
-//
-//  /**
-//   * Used to stub out some values that would normally be set during analyze() of a full transformation.
-//   */
-//  class TestableAnnotationDrivenAnalyzer extends AnnotationDrivenStepMetaAnalyzer {
-//
-//    TestableAnnotationDrivenAnalyzer( BaseStepMeta meta, Map<String, String> typeCategoryMap,
-//                                      EntityRegister register ) {
-//      super( meta, typeCategoryMap, register, new Variables() );
-//    }
-//
-//    {
-//      setMetaverseObjectFactory( new MetaverseObjectFactory() );
-//      rootNode = root;
-//    }
-//
-//    protected SubtransAnalyzer<BaseStepMeta> getSubtransAnalyzer() {
-//      return subtransAnalyzer;
-//    }
-//
-//    public Map<String, RowMetaInterface> getInputFields( final TransMeta parentTransMeta,
-//                                                         final StepMeta parentStepMeta ) {
-//
-//      return ImmutableMap.of( "Step1", inputRowMeta,
-//        "Step2", new RowMeta() );
-//    }
-//
-//    public StepNodes getOutputs() {
-//      StepNodes outputs = new StepNodes();
-//      outputs.addNode( "SomeNextStep", "messageFieldOut", outputMessageNode );
-//      outputs.addNode( "SomeNextStep", "topicFieldOut", outputTopicNode );
-//      return outputs;
-//    }
-//  }
-//
+  private Map<String, String> typeCategoryMap = new HashMap<>();
+  @Mock
+  AnnotationDrivenStepMetaAnalyzer.EntityRegister entityRegister;
+  private RowMeta inputRowMeta;
+  private RowMeta outputRowMeta;
+
+  @Mock
+  SubtransAnalyzer subtransAnalyzer;
+
+  private IMetaverseNode root = new MetaverseTransientNode( "rootNode" );
+  private IMetaverseNode outputMessageNode = new MetaverseTransientNode( "messageOutputNode" );
+  private IMetaverseNode outputTopicNode = new MetaverseTransientNode( "topicOutputNode" );
+  private StepMetaInterface meta;
+  private StepMetaInterface mappingMeta;
+  private TestableAnnotationDrivenAnalyzer analyzer;
+  private static IMetaverseNode subTransRoot = new MetaverseTransientNode( "subTransRootNode" );
+
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    KettleClientEnvironment.init();
+    PluginRegistry.addPluginType( ValueMetaPluginType.getInstance() );
+    PluginRegistry.init();
+  }
+
+  @Before
+  public void before() throws KettleException {
+    org.mockito.MockitoAnnotations.openMocks( this );
+    inputRowMeta = new RowMeta();
+    outputRowMeta = new RowMeta();
+
+    this.meta = getTestStepMeta( inputRowMeta );
+    outputMessageNode.setName( "messageOutputNode" );
+    outputMessageNode.setType( NODE_TYPE_TRANS_FIELD );
+    outputTopicNode.setName( "topicOutputNode" );
+    outputTopicNode.setType( NODE_TYPE_TRANS_FIELD );
+
+    analyzer = new TestableAnnotationDrivenAnalyzer( new TestStepMeta(), typeCategoryMap, entityRegister );
+    //doNothing().when( subtransAnalyzer ).linkResultFieldToSubTrans( any(), any(), any(), any() );
+  }
+
+
+  @After
+  public void after() {
+    // the act of creating a metaverse builder registers entities.  Clear them out so
+    // no state is carried forward.
+    DictionaryHelper.clearEntityRegistry();
+  }
+
+  @Test
+  public void testGetUsedFields() {
+    Set<StepField> usedFields = analyzer.getUsedFields( (BaseStepMeta) meta );
+    assertThat( usedFields.size(), equalTo( 5 ) );
+    List<String> usedList = usedFields.stream()
+      .map( StepField::getFieldName )
+      .sorted()
+      .collect( Collectors.toList() );
+    List<String> inputSteps = usedFields.stream()
+      .map( StepField::getStepName )
+      .sorted()
+      .collect( Collectors.toList() );
+    assertThat( usedList, equalTo( Arrays.asList( "messageField", "substitutedField",
+      "usedField", "usedField1", "usedField2" ) ) );
+    assertThat( inputSteps, equalTo( Arrays.asList( "Step1", "Step1", "Step1", "Step1", "Step1" ) ) );
+  }
+
+  @Test
+  public void testCustomAnalyze() throws MetaverseAnalyzerException {
+    IMetaverseBuilder builder = getBuilder( root );
+
+    analyzer.loadInputAndOutputStreamFields( (BaseStepMeta) meta );
+    analyzer.customAnalyze( (BaseStepMeta) meta, root );
+    Graph graph = builder.getGraph();
+
+    List<Edge> edges = getEdgesWithLabel( graph, LINK_READBY );
+
+    assertThat( edges.size(), equalTo( 1 ) );
+    Edge e = edges.get( 0 );
+
+    Vertex externalResourceV = e.outVertex();
+    assertThat( externalResourceV.value( "server" ), equalTo( "ServernameOrWhatever" ) );
+    assertThat( externalResourceV.value( "port" ), equalTo( "123" ) );
+    assertThat( externalResourceV.value( "isSsl" ), equalTo( "true" ) );
+    assertThat( externalResourceV.value( "name" ), equalTo( "ServernameOrWhatever" ) );
+    assertThat( externalResourceV.value( "type" ), equalTo( TEST_TYPE ) );
+
+    // nested properties in referenced class
+    assertThat( externalResourceV.value( "SUBPROP" ), equalTo( "subProp1" ) );
+    assertThat( externalResourceV.value( "subProp2" ), equalTo( "123" ) );
+    assertThat( externalResourceV.value( "method-property" ), equalTo( "blah" ) );
+
+    edges = getEdgesWithLabel( graph, LINK_DEPENDENCYOF );
+
+    assertThat( edges.size(), equalTo( 1 ) );
+    e = edges.get( 0 );
+
+    externalResourceV = e.outVertex();
+    assertThat( externalResourceV.value( "dbaddress" ), equalTo( "127.0.0.1:3363" ) );
+  }
+
+  @Test
+  public void testCustomAnalyzeSubtrans() throws MetaverseAnalyzerException, KettleException {
+    IMetaverseBuilder builder = getBuilder( root );
+
+    try ( MockedStatic<KettleAnalyzerUtil> ignored = Mockito.mockStatic( KettleAnalyzerUtil.class ) ) {
+      this.mappingMeta = getTestStepMappingMeta( inputRowMeta, outputRowMeta );
+      ignored.when( () -> KettleAnalyzerUtil.analyze( any(), any(), any(), any() ) ).thenReturn( subTransRoot );
+
+      analyzer.loadInputAndOutputStreamFields( (BaseStepMeta) mappingMeta );
+      // customAnalyze alone never wires the step/trans meta fields that analyze() sets via validateState
+      analyzer.validateState( null, (BaseStepMeta) mappingMeta );
+      analyzer.customAnalyze( (BaseStepMeta) mappingMeta, root );
+      Graph graph = builder.getGraph();
+
+      List<Edge> edges = getEdgesWithLabel( graph, LINK_READBY );
+
+      assertThat( edges.size(), equalTo( 1 ) );
+      Edge e = edges.get( 0 );
+
+      Vertex externalResourceV = e.outVertex();
+      assertThat( externalResourceV.value( "server" ), equalTo( "ServernameOrWhatever" ) );
+      assertThat( externalResourceV.value( "port" ), equalTo( "123" ) );
+      assertThat( externalResourceV.value( "isSsl" ), equalTo( "true" ) );
+      assertThat( externalResourceV.value( "name" ), equalTo( "ServernameOrWhatever" ) );
+      assertThat( externalResourceV.value( "type" ), equalTo( TEST_TYPE ) );
+
+      //verify server node "contains" the two input resources
+      List<Vertex> resourceNodes = new ArrayList<>();
+      externalResourceV.vertices( Direction.OUT ).forEachRemaining( v -> resourceNodes.add( v ) );
+      assertThat( resourceNodes.size(), equalTo( 3 ) );
+      Vertex messageVertex = resourceNodes.stream().filter( v -> v.value( PROPERTY_NAME ).equals( "message" ) )
+        .findFirst().get();
+      Vertex topicVertex = resourceNodes.stream().filter( v -> v.value( PROPERTY_NAME ).equals( "topic" ) ).findFirst()
+        .get();
+
+      assertThat( messageVertex.value( PROPERTY_TYPE ), equalTo( RESOURCE ) );
+      assertThat( topicVertex.value( PROPERTY_TYPE ), equalTo( RESOURCE ) );
+
+      // nested properties in referenced class
+      assertThat( externalResourceV.value( "SUBPROP" ), equalTo( "subProp1" ) );
+      assertThat( externalResourceV.value( "subProp2" ), equalTo( "123" ) );
+
+      edges = getEdgesWithLabel( graph, LINK_DEPENDENCYOF );
+
+      assertThat( edges.size(), equalTo( 1 ) );
+      e = edges.get( 0 );
+
+      externalResourceV = e.outVertex();
+      assertThat( externalResourceV.value( "dbaddress" ), equalTo( "127.0.0.1:3363" ) );
+
+      doNothing().when( subtransAnalyzer ).linkUsedFieldToSubTrans( any(), any(), any(), any(), any() );
+      doNothing().when( subtransAnalyzer ).linkResultFieldToSubTrans(
+        any( IMetaverseNode.class ), any( TransMeta.class ), any( IMetaverseNode.class ),
+        any( IComponentDescriptor.class ), any( String.class ) );
+
+      // verify subtrans analyzer was called on the expected nodes for input to subtrans
+      ArgumentCaptor<IMetaverseNode> usedFieldsNodeCaptor = ArgumentCaptor.forClass( IMetaverseNode.class );
+      ArgumentCaptor<IMetaverseNode> outputFieldsNodeCaptor = ArgumentCaptor.forClass( IMetaverseNode.class );
+
+      verify( subtransAnalyzer, times( 2 ) )
+        .linkResultFieldToSubTrans( outputFieldsNodeCaptor.capture(), any(), any(), any(), any() );
+      verify( subtransAnalyzer, times( 2 ) )
+        .linkUsedFieldToSubTrans( usedFieldsNodeCaptor.capture(), any(), any(), any(), any() );
+
+      IMetaverseNode messageNode = usedFieldsNodeCaptor.getAllValues().stream()
+        .filter( node -> node.getName().equals( "message" ) ).findFirst().get();
+      IMetaverseNode topicNode = usedFieldsNodeCaptor.getAllValues().stream()
+        .filter( node -> node.getName().equals( "topic" ) ).findFirst().get();
+
+      assertThat( usedFieldsNodeCaptor.getAllValues().size(), equalTo( 2 ) );
+      assertThat( topicNode.getType(), equalTo( RESOURCE ) );
+      assertThat( messageNode.getType(), equalTo( RESOURCE ) );
+
+      // verify subtrans analyzer was called on the expected nodes for output from subtrans
+      IMetaverseNode messageOutputNode = outputFieldsNodeCaptor.getAllValues().stream()
+        .filter( node -> node.getName().equals( "messageOutputNode" ) ).findFirst().get();
+      IMetaverseNode topicOutputNode = outputFieldsNodeCaptor.getAllValues().stream()
+        .filter( node -> node.getName().equals( "topicOutputNode" ) ).findFirst().get();
+
+      assertThat( outputFieldsNodeCaptor.getAllValues().size(), equalTo( 2 ) );
+      assertThat( topicOutputNode.getType(), equalTo( NODE_TYPE_TRANS_FIELD ) );
+      assertThat( messageOutputNode.getType(), equalTo( NODE_TYPE_TRANS_FIELD ) );
+    }
+  }
+
+  @Test
+  public void testResourceLinkage() throws MetaverseAnalyzerException {
+    IMetaverseBuilder builder = getBuilder( root );
+
+    MetaverseComponentDescriptor descriptor = new MetaverseComponentDescriptor(
+      "name", "type",
+      root, analyzer.getDescriptor().getContext() );
+
+    analyzer.analyze( descriptor, (BaseStepMeta) meta );
+    Graph graph = builder.getGraph();
+
+    List<Edge> edges = getEdgesWithLabel( graph, LINK_WRITESTO );
+
+    assertThat( edges.size(), equalTo( 2 ) );
+    edges.sort( Comparator.comparing( e -> e.inVertex().value( "name" ) ) );
+    assertEdge( edges.get( 0 ), "Bora Bora", "name" );
+    assertEdge( edges.get( 1 ), "message", "ServernameOrWhatever" );
+
+    edges = getEdgesWithLabel( graph, LINK_CONTAINS );
+    assertThat( edges.size(), equalTo( 1 ) );
+    assertEdge( edges.get( 0 ), "name", "private-field-value" );
+
+  }
+
+  private void assertEdge( Edge edge, String from, String to ) {
+    assertThat( edge.inVertex().value( "name" ), equalTo( from ) );
+    assertThat( edge.outVertex().value( "name" ), equalTo( to ) );
+  }
+
+  @Test
+  public void testCategoryLinks() {
+    assertThat( typeCategoryMap.get( CONN_TYPE ),
+      equalTo( CATEGORY_DATASOURCE ) );
+    assertThat( typeCategoryMap.get( TEST_TYPE ),
+      equalTo( CATEGORY_OTHER ) );
+  }
+
+  @Test
+  public void testEntityLinks() {
+
+    verify( entityRegister ).registerEntityTypes( LINK_PARENT_CONCEPT, CONN_TYPE, NODE_TYPE_EXTERNAL_CONNECTION );
+    verify( entityRegister ).registerEntityTypes( LINK_CONTAINS_CONCEPT, TEST_TYPE, CONN_TYPE );
+    verify( entityRegister ).registerEntityTypes( LINK_PARENT_CONCEPT, TEST_TYPE, null );
+  }
+
+  @Test
+  public void testGetSupportedSteps() {
+    assertThat( analyzer.getSupportedSteps(), equalTo( singleton( meta.getClass() ) ) );
+  }
+
+
+  private IMetaverseBuilder getBuilder( IMetaverseNode rootNode ) {
+    IComponentDescriptor descriptor = new MetaverseComponentDescriptor( "descriptor", "someType", rootNode );
+    analyzer.setDescriptor( descriptor );
+    IMetaverseBuilder builder = new BaseMetaverseBuilder( TinkerGraph.open() );
+    analyzer.setMetaverseBuilder( builder );
+    return builder;
+  }
+
+  private List<Edge> getEdgesWithLabel( Graph graph, String edgeName ) {
+    List<Edge> matches = new ArrayList<>();
+    graph.edges().forEachRemaining( edge -> {
+      if ( edge.label().equals( edgeName ) ) {
+        matches.add( edge );
+      }
+    } );
+    return matches;
+  }
+
+  /**
+   * Used to stub out some values that would normally be set during analyze() of a full transformation.
+   */
+  class TestableAnnotationDrivenAnalyzer extends AnnotationDrivenStepMetaAnalyzer {
+
+    TestableAnnotationDrivenAnalyzer( BaseStepMeta meta, Map<String, String> typeCategoryMap,
+                                      EntityRegister register ) {
+      super( meta, typeCategoryMap, register, new Variables() );
+    }
+
+    {
+      setMetaverseObjectFactory( new MetaverseObjectFactory() );
+      rootNode = root;
+    }
+
+    protected SubtransAnalyzer<BaseStepMeta> getSubtransAnalyzer() {
+      return subtransAnalyzer;
+    }
+
+    public Map<String, RowMetaInterface> getInputFields( final TransMeta parentTransMeta,
+                                                         final StepMeta parentStepMeta ) {
+
+      return ImmutableMap.of( "Step1", inputRowMeta,
+        "Step2", new RowMeta() );
+    }
+
+    public StepNodes getOutputs() {
+      StepNodes outputs = new StepNodes();
+      outputs.addNode( "SomeNextStep", "messageFieldOut", outputMessageNode );
+      outputs.addNode( "SomeNextStep", "topicFieldOut", outputTopicNode );
+      return outputs;
+    }
+  }
+
   static TestStepMeta getTestStepMeta( RowMeta inputRowMeta ) {
     TestStepMeta meta = new TestStepMeta(); // step meta with metaverse annotations
 
@@ -352,148 +431,150 @@ public class AnnotationDrivenStepMetaAnalyzerTest {
     transMeta.addStep( parentStepMeta );
     return meta;
   }
-//
-//  static TestStepMappingMeta getTestStepMappingMeta( RowMeta inputRowMeta, RowMeta outputRowMeta ) throws KettleException {
-//    PowerMockito.mockStatic( KettleAnalyzerUtil.class );
-//    TestStepMappingMeta meta = new TestStepMappingMeta(); // step meta with metaverse annotations
-//
-//    inputRowMeta.addValueMeta( new ValueMetaString( "usedField" ) );
-//    inputRowMeta.addValueMeta( new ValueMetaString( "usedField1" ) );
-//    inputRowMeta.addValueMeta( new ValueMetaString( "usedField2" ) );
-//    inputRowMeta.addValueMeta( new ValueMetaString( "messageField" ) );
-//    inputRowMeta.addValueMeta( new ValueMetaString( "substitutedField" ) );
-//
-//    outputRowMeta.addValueMeta( new ValueMetaString( "messageFieldOut" ) );
-//    outputRowMeta.addValueMeta( new ValueMetaString( "topicFieldOut" ) );
-//
-//    StepMeta parentStepMeta = new StepMeta();
-//    final Variables variables = new Variables();
-//    variables.setVariable( "substitute", "substitutedField" );
-//
-//    TransMeta transMeta = spy( new TransMeta( variables ) );
-//    TransMeta subTransMeta = spy( new TransMeta( variables ) );
-//
-//    Repository repository = mock( Repository.class );
-//    RepositoryDirectory repositoryDirectory = mock( RepositoryDirectory.class );
-//
-//    transMeta.setRepository( repository );
-//
-//    when( repository.findDirectory( any( String.class ) ) ).thenReturn( repositoryDirectory );
-//    when( repository.loadTransformation( any( String.class ), eq( repositoryDirectory ), any( ProgressMonitorListener.class ), any( Boolean.class ), any( String.class ) ) ).thenReturn( subTransMeta );
-//
-//    // stub out previous step input
-//    try {
-//      when( transMeta.getPrevStepFields( any(), any(), any() ) ).thenReturn( inputRowMeta );
-//    } catch ( KettleStepException e ) {
-//      throw new IllegalStateException( e );
-//    }
-//
-//    // stub out output
-//    try {
-//      when( transMeta.getStepFields( any(), any() ) ).thenReturn( outputRowMeta );
-//    } catch ( KettleStepException e ) {
-//      throw new IllegalStateException( e );
-//    }
-//
-//    meta.setParentStepMeta( parentStepMeta );
-//    parentStepMeta.setStepMetaInterface( meta );
-//    StepIOMeta stepIOMeta = new StepIOMeta( true, true, true,
-//      false, false, false );
-//
-//    meta.setStepIOMeta( stepIOMeta );
-//    transMeta.addStep( parentStepMeta );
-//
-//    StepMeta firstSubStepMeta = new StepMeta();
-//    StepMeta secondSubStepMeta = new StepMeta();
-//    RowsFromResultMeta rowsFromResultMeta = new RowsFromResultMeta();
-//    WriteToLogMeta writeToLogMeta = new WriteToLogMeta();
-//
-//    String[] fieldNameArray = new String[] { "messageFieldOut", "topicFieldOut" };
-//    int[] typeArray = new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING  };
-//    int[] lengthArray = new int[] { 0, 0 };
-//    int[] precisionArray = new int[] { 0, 0 };
-//
-//    rowsFromResultMeta.setFieldname( fieldNameArray );
-//    rowsFromResultMeta.setType( typeArray );
-//    rowsFromResultMeta.setPrecision( precisionArray );
-//    rowsFromResultMeta.setLength( lengthArray );
-//    writeToLogMeta.setFieldName( fieldNameArray );
-//
-//    rowsFromResultMeta.setParentStepMeta( firstSubStepMeta );
-//    writeToLogMeta.setParentStepMeta( secondSubStepMeta );
-//    firstSubStepMeta.setStepMetaInterface( rowsFromResultMeta );
-//    firstSubStepMeta.setName( "Rows from result" );
-//    secondSubStepMeta.setStepMetaInterface( writeToLogMeta );
-//    secondSubStepMeta.setName( "Write to log" );
-//    rowsFromResultMeta.setStepIOMeta( stepIOMeta );
-//    writeToLogMeta.setStepIOMeta( stepIOMeta );
-//    subTransMeta.addStep( firstSubStepMeta );
-//    subTransMeta.addStep( secondSubStepMeta );
-//    subTransMeta.addTransHop( new TransHopMeta( firstSubStepMeta, secondSubStepMeta, true ) );
-//    subTransMeta.setName( "SubTransMetaName" );
-//
-//    try {
-//      when( KettleAnalyzerUtil.analyze( any(), any(), any(), any() ) ).thenReturn( subTransRoot );
-//    } catch ( MetaverseAnalyzerException e ) {
-//      fail( e.getMessage() );
-//    }
-//
-//    return meta;
-//  }
-//
-//
-//  @Metaverse.CategoryMap ( entity = CONN_TYPE, category = CATEGORY_DATASOURCE )
-//  @Metaverse.CategoryMap ( entity = TEST_TYPE, category = CATEGORY_OTHER )
-//  @Metaverse.EntityLink ( entity = CONN_TYPE, link = LINK_PARENT_CONCEPT, parentEntity =
-//    NODE_TYPE_EXTERNAL_CONNECTION )
-//  @Metaverse.EntityLink ( entity = TEST_TYPE, link = LINK_CONTAINS_CONCEPT, parentEntity = CONN_TYPE )
-//  @Metaverse.EntityLink ( entity = TEST_TYPE, link = LINK_PARENT_CONCEPT )
-//  @SuppressWarnings ( "unused" )
+
+  static TestStepMappingMeta getTestStepMappingMeta( RowMeta inputRowMeta, RowMeta outputRowMeta )
+    throws KettleException {
+    TestStepMappingMeta meta = new TestStepMappingMeta(); // step meta with metaverse annotations
+
+    inputRowMeta.addValueMeta( new ValueMetaString( "usedField" ) );
+    inputRowMeta.addValueMeta( new ValueMetaString( "usedField1" ) );
+    inputRowMeta.addValueMeta( new ValueMetaString( "usedField2" ) );
+    inputRowMeta.addValueMeta( new ValueMetaString( "messageField" ) );
+    inputRowMeta.addValueMeta( new ValueMetaString( "substitutedField" ) );
+
+    outputRowMeta.addValueMeta( new ValueMetaString( "messageFieldOut" ) );
+    outputRowMeta.addValueMeta( new ValueMetaString( "topicFieldOut" ) );
+
+    StepMeta parentStepMeta = new StepMeta();
+    final Variables variables = new Variables();
+    variables.setVariable( "substitute", "substitutedField" );
+
+    TransMeta transMeta = spy( new TransMeta( variables ) );
+    TransMeta subTransMeta = spy( new TransMeta( variables ) );
+
+    Repository repository = mock( Repository.class );
+    RepositoryDirectory repositoryDirectory = mock( RepositoryDirectory.class );
+
+    org.mockito.Mockito.doReturn( repository ).when( transMeta ).getRepository();
+    when( repository.findDirectory( any( String.class ) ) ).thenReturn( repositoryDirectory );
+    when( repository.loadTransformation( any( String.class ), eq( repositoryDirectory ), any(
+      ProgressMonitorListener.class ), any( Boolean.class ), any( String.class ) ) ).thenReturn( subTransMeta );
+
+    // stub out previous step input
+    try {
+      when( transMeta.getPrevStepFields( any(), any(), any() ) ).thenReturn( inputRowMeta );
+    } catch ( KettleStepException e ) {
+      throw new IllegalStateException( e );
+    }
+
+    // stub out output
+    try {
+      when( transMeta.getStepFields( any(), any() ) ).thenReturn( outputRowMeta );
+    } catch ( KettleStepException e ) {
+      throw new IllegalStateException( e );
+    }
+
+    meta.setParentStepMeta( parentStepMeta );
+    parentStepMeta.setStepMetaInterface( meta );
+    StepIOMeta stepIOMeta = new StepIOMeta( true, true, true,
+      false, false, false );
+
+    meta.setStepIOMeta( stepIOMeta );
+    transMeta.addStep( parentStepMeta );
+
+    StepMeta firstSubStepMeta = new StepMeta();
+    StepMeta secondSubStepMeta = new StepMeta();
+    RowsFromResultMeta rowsFromResultMeta = new RowsFromResultMeta();
+    WriteToLogMeta writeToLogMeta = new WriteToLogMeta();
+
+    String[] fieldNameArray = new String[] { "messageFieldOut", "topicFieldOut" };
+    int[] typeArray = new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING };
+    int[] lengthArray = new int[] { 0, 0 };
+    int[] precisionArray = new int[] { 0, 0 };
+
+    rowsFromResultMeta.setFieldname( fieldNameArray );
+    rowsFromResultMeta.setType( typeArray );
+    rowsFromResultMeta.setPrecision( precisionArray );
+    rowsFromResultMeta.setLength( lengthArray );
+    writeToLogMeta.setFieldName( fieldNameArray );
+
+    rowsFromResultMeta.setParentStepMeta( firstSubStepMeta );
+    writeToLogMeta.setParentStepMeta( secondSubStepMeta );
+    firstSubStepMeta.setStepMetaInterface( rowsFromResultMeta );
+    firstSubStepMeta.setName( "Rows from result" );
+    secondSubStepMeta.setStepMetaInterface( writeToLogMeta );
+    secondSubStepMeta.setName( "Write to log" );
+    rowsFromResultMeta.setStepIOMeta( stepIOMeta );
+    writeToLogMeta.setStepIOMeta( stepIOMeta );
+    subTransMeta.addStep( firstSubStepMeta );
+    subTransMeta.addStep( secondSubStepMeta );
+    subTransMeta.addTransHop( new TransHopMeta( firstSubStepMeta, secondSubStepMeta, true ) );
+    subTransMeta.setName( "SubTransMetaName" );
+
+    return meta;
+  }
+
+
+  @Metaverse.CategoryMap( entity = CONN_TYPE, category = CATEGORY_DATASOURCE )
+  @Metaverse.CategoryMap( entity = TEST_TYPE, category = CATEGORY_OTHER )
+  @Metaverse.EntityLink( entity = CONN_TYPE, link = LINK_PARENT_CONCEPT, parentEntity = NODE_TYPE_EXTERNAL_CONNECTION )
+  @Metaverse.EntityLink( entity = TEST_TYPE, link = LINK_CONTAINS_CONCEPT, parentEntity = CONN_TYPE )
+  @Metaverse.EntityLink( entity = TEST_TYPE, link = LINK_PARENT_CONCEPT )
+  @SuppressWarnings( "unused" )
   static class TestStepMeta extends BaseStepMeta implements StepMetaInterface {
 
     static final String CONN_TYPE = "test_conn_type";
     static final String TEST_TYPE = "test_type";
 
-    @Metaverse.Property public String field1 = "usedField";
-    @Metaverse.Property public String field2 = "usedField1";
-    @Metaverse.Property public String field3 = "usedField2";
-    @Metaverse.Property public String envSubstituteAttr = "${substitute}";
+    @Metaverse.Property
+    public String field1 = "usedField";
+    @Metaverse.Property
+    public String field2 = "usedField1";
+    @Metaverse.Property
+    public String field3 = "usedField2";
+    @Metaverse.Property
+    public String envSubstituteAttr = "${substitute}";
     public String otherMeta;
     public String otherMeta2;
 
     @InjectionDeep
     public SubMeta subMeta = new SubMeta();
 
-    @Metaverse.Node ( link = LINK_READBY, type = TEST_TYPE, name = "test_name" )
-    @Metaverse.Property ( name = "server", parentNodeName = "test_name" ) public String serverER =
+    @Metaverse.Node( link = LINK_READBY, type = TEST_TYPE, name = "test_name" )
+    @Metaverse.Property( name = "server", parentNodeName = "test_name" )
+    public String serverER =
       "ServernameOrWhatever";
-    @Metaverse.Property ( name = "port", parentNodeName = "test_name" ) public int portER = 123;
-    @Metaverse.Property ( name = "isSsl", parentNodeName = "test_name" ) public boolean isSslER = true;
+    @Metaverse.Property( name = "port", parentNodeName = "test_name" )
+    public int portER = 123;
+    @Metaverse.Property( name = "isSsl", parentNodeName = "test_name" )
+    public boolean isSslER = true;
 
-    @Metaverse.Node ( name = "message", type = RESOURCE, link = LINK_DEFINES, nameFromValue = "FALSE" )
-    @Metaverse.Property ( name = "message", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
-    @Metaverse.NodeLink ( nodeName = "message", parentNodeName = "test_name", parentNodelink = LINK_WRITESTO,
+    @Metaverse.Node( name = "message", type = RESOURCE, link = LINK_DEFINES, nameFromValue = "FALSE" )
+    @Metaverse.Property( name = "message", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
+    @Metaverse.NodeLink( nodeName = "message", parentNodeName = "test_name", parentNodelink = LINK_WRITESTO,
       linkDirection = "OUT" )
     public String message = "messageField";
 
-    @Metaverse.Node ( name = "vacataion_spot", type = TEST_TYPE, link = LINK_WRITESTO, linkDirection = "IN" )
+    @Metaverse.Node( name = "vacataion_spot", type = TEST_TYPE, link = LINK_WRITESTO, linkDirection = "IN" )
     public String destination = "Bora Bora";
 
-    @Metaverse.Node ( type = CONN_TYPE, name = "test_conn_name" )
-    @Metaverse.Property ( name = "dbaddress", parentNodeName = "test_conn_name" ) public String dbaddress =
+    @Metaverse.Node( type = CONN_TYPE, name = "test_conn_name" )
+    @Metaverse.Property( name = "dbaddress", parentNodeName = "test_conn_name" )
+    public String dbaddress =
       "127.0.0.1:3363";
 
-    @Metaverse.Property ( name = "method-property", parentNodeName = "test_name" )
+    @Metaverse.Property( name = "method-property", parentNodeName = "test_name" )
     public String methodProperty() {
       return "blah";
     }
 
-    @Metaverse.Node ( name = "method-node", type = "otherType", link = LINK_CONTAINS )
+    @Metaverse.Node( name = "method-node", type = "otherType", link = LINK_CONTAINS )
     public String methodNode() {
       return "private-field-value";
     }
 
-    @Override public void setDefault() {
+    @Override
+    public void setDefault() {
 
     }
 
@@ -503,109 +584,126 @@ public class AnnotationDrivenStepMetaAnalyzerTest {
       return null;
     }
 
-    @Override public StepDataInterface getStepData() {
+    @Override
+    public StepDataInterface getStepData() {
       return null;
     }
   }
-//
-//  @Metaverse.CategoryMap ( entity = CONN_TYPE, category = CATEGORY_DATASOURCE )
-//  @Metaverse.CategoryMap ( entity = TEST_TYPE, category = CATEGORY_OTHER )
-//  @Metaverse.EntityLink ( entity = CONN_TYPE, link = LINK_PARENT_CONCEPT, parentEntity =
-//    NODE_TYPE_EXTERNAL_CONNECTION )
-//  @Metaverse.EntityLink ( entity = TEST_TYPE, link = LINK_CONTAINS_CONCEPT, parentEntity = CONN_TYPE )
-//  @Metaverse.EntityLink ( entity = TEST_TYPE, link = LINK_PARENT_CONCEPT )
-//  @SuppressWarnings ( "unused" )
-//  static class TestStepMappingMeta extends BaseStreamStepMeta implements StepMetaInterface, ISubTransAwareMeta {
-//
-//    static final String CONN_TYPE = "test_conn_type";
-//    static final String TEST_TYPE = "test_type";
-//
-//    @Metaverse.Property public String field1 = "usedField";
-//    @Metaverse.Property public String field2 = "usedField1";
-//    @Metaverse.Property public String field3 = "usedField2";
-//    @Metaverse.Property public String envSubstituteAttr = "${substitute}";
-//    public String otherMeta;
-//    public String otherMeta2;
-//
-//    @InjectionDeep
-//    public SubMeta subMeta = new SubMeta();
-//
-//    @Metaverse.Node ( link = LINK_READBY, type = TEST_TYPE, name = "test_name" )
-//    @Metaverse.Property ( name = "server", parentNodeName = "test_name" ) public String serverER =
-//      "ServernameOrWhatever";
-//    @Metaverse.Property ( name = "port", parentNodeName = "test_name" ) public int portER = 123;
-//    @Metaverse.Property ( name = "isSsl", parentNodeName = "test_name" ) public boolean isSslER = true;
-//
-//    @Metaverse.Node ( name = "message", type = RESOURCE, link = LINK_INPUTS, nameFromValue = FALSE, subTransLink = SUBTRANS_INPUT )
-//    @Metaverse.Property ( name = "message", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
-//    @Metaverse.NodeLink ( nodeName = "message", parentNodeName = "test_name", parentNodelink = LINK_CONTAINS,
-//      linkDirection = "OUT" )
-//    public String message = "messageField";
-//
-//
-//    @Metaverse.Node ( name = "topic", type = RESOURCE, link = LINK_INPUTS, nameFromValue = FALSE, subTransLink = SUBTRANS_INPUT )
-//    @Metaverse.Property ( name = "topic", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
-//    @Metaverse.NodeLink ( nodeName = "topic", parentNodeName = "test_name", parentNodelink = LINK_CONTAINS,
-//      linkDirection = "OUT" )
-//    public String topic = "topicField";
-//
-//    @Metaverse.Node ( name = "vacataion_spot", type = TEST_TYPE, link = LINK_WRITESTO, linkDirection = "IN" )
-//    public String destination = "Bora Bora";
-//
-//    @Metaverse.Node ( type = CONN_TYPE, name = "test_conn_name" )
-//    @Metaverse.Property ( name = "dbaddress", parentNodeName = "test_conn_name" ) public String dbaddress =
-//      "127.0.0.1:3363";
-//
-//    @Override public void setDefault() {
-//
-//    }
-//
-//    @Override
-//    public RowMeta getRowMeta( String s, VariableSpace variableSpace ) throws KettleStepException {
-//      return null;
-//    }
-//
-//    @Override
-//    public String getSubStep() {
-//      return "Write to log";
-//    }
-//
-//    @Override
-//    public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int i, TransMeta transMeta,
-//                                  Trans trans ) {
-//      return null;
-//    }
-//
-//    @Override public StepDataInterface getStepData() {
-//      return null;
-//    }
-//
-//    @Override public String getTransName() {
-//      return "TestTransName";
-//    }
-//
-//    @Override public String getDirectoryPath() {
-//      return "/";
-//    }
-//
-//    public TestStepMappingMeta() {
-//      super();
-//      setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-//    }
-//  }
-//
-//  /**
-//   * Used to test meta elements in referenced objects.
-//   * (similar to @InjectionDeep with Metadata injection
-//   */
-//  @Metaverse
-//  @SuppressWarnings ( "unused" )
+
+  @Metaverse.CategoryMap( entity = CONN_TYPE, category = CATEGORY_DATASOURCE )
+  @Metaverse.CategoryMap( entity = TEST_TYPE, category = CATEGORY_OTHER )
+  @Metaverse.EntityLink( entity = CONN_TYPE, link = LINK_PARENT_CONCEPT, parentEntity = NODE_TYPE_EXTERNAL_CONNECTION )
+  @Metaverse.EntityLink( entity = TEST_TYPE, link = LINK_CONTAINS_CONCEPT, parentEntity = CONN_TYPE )
+  @Metaverse.EntityLink( entity = TEST_TYPE, link = LINK_PARENT_CONCEPT )
+  @SuppressWarnings( "unused" )
+  static class TestStepMappingMeta extends BaseStreamStepMeta implements StepMetaInterface, ISubTransAwareMeta {
+
+    static final String CONN_TYPE = "test_conn_type";
+    static final String TEST_TYPE = "test_type";
+
+    @Metaverse.Property
+    public String field1 = "usedField";
+    @Metaverse.Property
+    public String field2 = "usedField1";
+    @Metaverse.Property
+    public String field3 = "usedField2";
+    @Metaverse.Property
+    public String envSubstituteAttr = "${substitute}";
+    public String otherMeta;
+    public String otherMeta2;
+
+    @InjectionDeep
+    public SubMeta subMeta = new SubMeta();
+
+    @Metaverse.Node( link = LINK_READBY, type = TEST_TYPE, name = "test_name" )
+    @Metaverse.Property( name = "server", parentNodeName = "test_name" )
+    public String serverER =
+      "ServernameOrWhatever";
+    @Metaverse.Property( name = "port", parentNodeName = "test_name" )
+    public int portER = 123;
+    @Metaverse.Property( name = "isSsl", parentNodeName = "test_name" )
+    public boolean isSslER = true;
+
+    @Metaverse.Node( name = "message", type = RESOURCE, link = LINK_INPUTS, nameFromValue = FALSE, subTransLink =
+      SUBTRANS_INPUT )
+    @Metaverse.Property( name = "message", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
+    @Metaverse.NodeLink( nodeName = "message", parentNodeName = "test_name", parentNodelink = LINK_CONTAINS,
+      linkDirection = "OUT" )
+    public String message = "messageField";
+
+
+    @Metaverse.Node( name = "topic", type = RESOURCE, link = LINK_INPUTS, nameFromValue = FALSE, subTransLink =
+      SUBTRANS_INPUT )
+    @Metaverse.Property( name = "topic", parentNodeName = "test_name", category = CATEGORY_MESSAGE_QUEUE )
+    @Metaverse.NodeLink( nodeName = "topic", parentNodeName = "test_name", parentNodelink = LINK_CONTAINS,
+      linkDirection = "OUT" )
+    public String topic = "topicField";
+
+    @Metaverse.Node( name = "vacataion_spot", type = TEST_TYPE, link = LINK_WRITESTO, linkDirection = "IN" )
+    public String destination = "Bora Bora";
+
+    @Metaverse.Node( type = CONN_TYPE, name = "test_conn_name" )
+    @Metaverse.Property( name = "dbaddress", parentNodeName = "test_conn_name" )
+    public String dbaddress =
+      "127.0.0.1:3363";
+
+    @Override
+    public void setDefault() {
+
+    }
+
+    @Override
+    public RowMeta getRowMeta( String s, VariableSpace variableSpace ) throws KettleStepException {
+      return null;
+    }
+
+    @Override
+    public String getSubStep() {
+      return "Write to log";
+    }
+
+    @Override
+    public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int i, TransMeta transMeta,
+                                  Trans trans ) {
+      return null;
+    }
+
+    @Override
+    public StepDataInterface getStepData() {
+      return null;
+    }
+
+    @Override
+    public String getTransName() {
+      return "TestTransName";
+    }
+
+    @Override
+    public String getDirectoryPath() {
+      return "/";
+    }
+
+    public TestStepMappingMeta() {
+      super();
+      // kettle's MetaFileLoaderImpl tries the file system first; a real ktr path keeps
+      // loadMappingMeta working without a repository
+      setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+      setFileName( "../core/src/it/resources/repo/validation/filter_rows.ktr" );
+    }
+  }
+
+  /**
+   * Used to test meta elements in referenced objects.
+   * (similar to @InjectionDeep with Metadata injection
+   */
+  @Metaverse
+  @SuppressWarnings( "unused" )
   static class SubMeta {
 
-    @Metaverse.Property ( name = "SUBPROP", parentNodeName = "test_name" )
+    @Metaverse.Property( name = "SUBPROP", parentNodeName = "test_name" )
     public String someSubProp = "subProp1";
 
-    @Metaverse.Property ( name = "subProp2", parentNodeName = "test_name" )
+    @Metaverse.Property( name = "subProp2", parentNodeName = "test_name" )
     public int subPropNum2 = 123;
 
   }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -235,15 +235,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.9</version>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>rest-core</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- TODO: uncomment once https://jira.pentaho.com/browse/ENGOPS-4612 is resolved -->
@@ -288,6 +282,33 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>stage-rest-plugin-for-its</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.pentaho.di.plugins</groupId>
+                  <artifactId>rest-core</artifactId>
+                  <version>${project.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <!-- KettleEnvironment.init() scans KETTLE_PLUGIN_BASE_FOLDERS (target/spoon/plugins,
+                   see IntegrationTestUtil) for @Step-annotated plugin jars -->
+              <outputDirectory>${project.build.directory}/spoon/plugins/rest-core</outputDirectory>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${maven-pmd-plugin.version}</version>

--- a/core/simple-jndi/jdbc.properties
+++ b/core/simple-jndi/jdbc.properties
@@ -1,0 +1,20 @@
+# ******************************************************************************
+#
+# Pentaho
+#
+# Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE.TXT file.
+#
+# Change Date: 2030-06-15
+# ******************************************************************************
+
+# simple-jndi datasource for integration tests; kettle's JndiUtil points
+# org.osjava.sj.root at the ./simple-jndi directory (working dir = core/ during ITs).
+# The H2 database files ship in src/it/resources/repo/.
+SampleData/type=javax.sql.DataSource
+SampleData/driver=org.h2.Driver
+SampleData/url=jdbc:h2:file:./src/it/resources/repo/SampleData;AUTO_SERVER=TRUE
+SampleData/user=
+SampleData/password=

--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDedupIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationDedupIT.java
@@ -11,19 +11,15 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
 import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,21 +30,28 @@ import static org.junit.Assert.assertTrue;
  * Runs the integration test with the {@link MetaverseConfig} mocked to have
  * the {@code deduplicateTransformationFields} graph dedupping turned on.
  */
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 public class MetaverseValidationDedupIT extends MetaverseValidationIT {
+
+  private static MockedStatic<MetaverseConfig> metaverseConfigMock;
 
   @BeforeClass
   public static void init() throws Exception {
 
-    PowerMockito.mockStatic( MetaverseConfig.class );
-    Mockito.when( MetaverseConfig.adjustExternalResourceFields() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.deduplicateTransformationFields() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.consolidateSubGraphs() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.generateSubGraphs() ).thenReturn( true );
+    metaverseConfigMock = Mockito.mockStatic( MetaverseConfig.class, Mockito.CALLS_REAL_METHODS );
+    metaverseConfigMock.when( MetaverseConfig::adjustExternalResourceFields ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::deduplicateTransformationFields ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::consolidateSubGraphs ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::generateSubGraphs ).thenReturn( true );
 
     MetaverseValidationIT.init();
+  }
+
+  @AfterClass
+  public static void tearDownMock() {
+    if ( metaverseConfigMock != null ) {
+      metaverseConfigMock.close();
+      metaverseConfigMock = null;
+    }
   }
 
   @Test

--- a/core/src/it/java/org/pentaho/metaverse/MetaverseValidationSkipDedupIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/MetaverseValidationSkipDedupIT.java
@@ -11,39 +11,42 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Runs the integration test with the {@link MetaverseConfig} mocked to have
  * the {@code deduplicateTransformationFields} graph dedupping turned off.
  */
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 public class MetaverseValidationSkipDedupIT extends MetaverseValidationIT {
+
+  private static MockedStatic<MetaverseConfig> metaverseConfigMock;
 
   @BeforeClass
   public static void init() throws Exception {
 
-    PowerMockito.mockStatic( MetaverseConfig.class );
+    metaverseConfigMock = Mockito.mockStatic( MetaverseConfig.class, Mockito.CALLS_REAL_METHODS );
     // expecting to deduplicate by default - need to mock to return false
-    Mockito.when( MetaverseConfig.adjustExternalResourceFields() ).thenReturn( false );
-    Mockito.when( MetaverseConfig.deduplicateTransformationFields() ).thenReturn( false );
-    Mockito.when( MetaverseConfig.consolidateSubGraphs() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.generateSubGraphs() ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::adjustExternalResourceFields ).thenReturn( false );
+    metaverseConfigMock.when( MetaverseConfig::deduplicateTransformationFields ).thenReturn( false );
+    metaverseConfigMock.when( MetaverseConfig::consolidateSubGraphs ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::generateSubGraphs ).thenReturn( true );
 
     MetaverseValidationIT.init();
+  }
+
+  @AfterClass
+  public static void tearDownMock() {
+    if ( metaverseConfigMock != null ) {
+      metaverseConfigMock.close();
+      metaverseConfigMock = null;
+    }
   }
 
   @Test

--- a/core/src/it/java/org/pentaho/metaverse/client/LineageClientIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/client/LineageClientIT.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.client;
 
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -79,7 +78,10 @@ public class LineageClientIT {
   }
 
   @AfterClass
-  public static void cleanUp() {
+  public static void cleanUp() throws Exception {
+    // drain async lineage analysis before tearing down PentahoSystem; otherwise worker threads
+    // keep analyzing against a torn-down system and race the next test class in the shared fork JVM
+    org.pentaho.metaverse.graph.LineageGraphCompletionService.getInstance().waitTillEmpty();
     IntegrationTestUtil.shutdownPentahoSystem();
   }
 

--- a/core/src/it/java/org/pentaho/metaverse/frames/RootNode.java
+++ b/core/src/it/java/org/pentaho/metaverse/frames/RootNode.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.frames;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -69,14 +68,16 @@ public class RootNode extends Concept {
 
   public List<JobNode> getJobs() {
     List<Vertex> list = graph.traversal().V( vertex.id() )
-      .repeat( __.out() ).emit( __.has( "name", "Job" ) ).until( __.loops().is( P.gte( 5 ) ) )
+      .repeat( __.out() ).until( __.has( "name", "Job" ).or().loops().is( P.gte( 5 ) ) )
+      .has( "name", "Job" )
       .out( "typeconcept" ).dedup().toList();
     return wrapAs( list.iterator(), v -> new JobNode( v, graph ) );
   }
 
   public JobNode getJob( String name ) {
     List<Vertex> result = graph.traversal().V( vertex.id() )
-      .repeat( __.out() ).emit( __.has( "name", "Job" ) ).until( __.loops().is( P.gte( 5 ) ) )
+      .repeat( __.out() ).until( __.has( "name", "Job" ).or().loops().is( P.gte( 5 ) ) )
+      .has( "name", "Job" )
       .out().has( "name", name ).dedup().toList();
     return result.isEmpty() ? null : new JobNode( result.get( 0 ), graph );
   }
@@ -115,7 +116,8 @@ public class RootNode extends Concept {
 
   public List<DatasourceNode> getDatasourceNodes() {
     List<Vertex> list = graph.traversal().V( vertex.id() )
-      .repeat( __.out() ).emit( __.has( "name", "Database Connection" ) ).until( __.loops().is( P.gte( 5 ) ) )
+      .repeat( __.out() ).until( __.has( "name", "Database Connection" ).or().loops().is( P.gte( 5 ) ) )
+      .has( "name", "Database Connection" )
       .out().toList();
     return wrapAs( list.iterator(), v -> new DatasourceNode( v, graph ) );
   }
@@ -196,9 +198,9 @@ public class RootNode extends Concept {
   public FilterRowsStepNode getFilterRowsStepNode( String name ) {
     List<Vertex> result = graph.traversal().V( vertex.id() )
       .repeat( __.out() )
-      .emit( __.has( "type", "Transformation Step" ).has( "name", name ) )
-      .until( __.loops().is( P.gte( 20 ) ) )
-      .as( "step" ).in( "contains" ).has( "name", "filter_rows" ).select( "step" )
+      .until( __.has( "type", "Transformation Step" ).has( "name", name ).or().loops().is( P.gte( 20 ) ) )
+      .has( "type", "Transformation Step" ).has( "name", name )
+      .as( "step" ).in( "contains" ).has( "name", "filter_rows" ).<Vertex>select( "step" )
       .toList();
     return result.isEmpty() ? null : new FilterRowsStepNode( result.get( 0 ), graph );
   }
@@ -231,7 +233,7 @@ public class RootNode extends Concept {
       .out().has( "name", "Transformation" )
       .out().has( "name", "Transformation Step" )
       .out( "typeconcept" ).has( "name", stepName )
-      .as( "step" ).in( "contains" ).has( "name", transformationName ).select( "step" )
+      .as( "step" ).in( "contains" ).has( "name", transformationName ).<Vertex>select( "step" )
       .toList();
     return result.isEmpty() ? null : factory.apply( result.get( 0 ) );
   }

--- a/core/src/it/java/org/pentaho/metaverse/graph/GraphCatalogWriterIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/graph/GraphCatalogWriterIT.java
@@ -11,11 +11,10 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.graph;
 
-import org.junit.Assert;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -37,15 +36,30 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 
 public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
-  @Mock ICatalogLineageClient mockCatalogLineageClient;
-  @Captor ArgumentCaptor<List<LineageDataResource>> inputSourceCaptor;
-  @Captor ArgumentCaptor<List<LineageDataResource>> outputSourcesCaptor;
-  @Mock ICatalogLineageClientProvider mockCatalogLineageClientProvider;
+  private AutoCloseable mocks;
+  @Mock
+  ICatalogLineageClient mockCatalogLineageClient;
+  @Captor
+  ArgumentCaptor<List<LineageDataResource>> inputSourceCaptor;
+  @Captor
+  ArgumentCaptor<List<LineageDataResource>> outputSourcesCaptor;
+  @Mock
+  ICatalogLineageClientProvider mockCatalogLineageClientProvider;
 
   @Before
   public void setup() {
-    Mockito.when( mockCatalogLineageClientProvider.getCatalogLineageClient( anyString(), anyString(), anyString(), anyString(), anyString(), anyString() ) )
+    mocks = org.mockito.MockitoAnnotations.openMocks( this );
+    Mockito.when( mockCatalogLineageClientProvider.getCatalogLineageClient( anyString(), anyString(), anyString(),
+        anyString(), anyString(), anyString() ) )
       .thenReturn( mockCatalogLineageClient );
+  }
+
+  @After
+  public void tearDownMocks() throws Exception {
+    if ( mocks != null ) {
+      mocks.close();
+      mocks = null;
+    }
   }
 
   @Test
@@ -59,8 +73,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
 
     graphCatalogWriter.outputGraphImpl( graph, null );
 
-    Path personCsvPath = Paths.get("src", "it", "resources", "person.csv");
-    Path personDetailsCsvPath = Paths.get("src", "it", "resources", "person_details.csv");
+    Path personCsvPath = Paths.get( "src", "it", "resources", "person.csv" );
+    Path personDetailsCsvPath = Paths.get( "src", "it", "resources", "person_details.csv" );
 
     LineageDataResource personCsv = new LineageDataResource( "person.csv" );
     personCsv.setPath( personCsvPath.toAbsolutePath().toString() );
@@ -71,7 +85,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
     List<String> personDetailsFields = Arrays.asList( "gender", "ip_address", "id", "age", "email" );
     personDetailsCsv.setFields( personDetailsFields );
     LineageDataResource outputTarget = new LineageDataResource( "CombinedCsvToTextOut.csv" );
-    outputTarget.setPath( "/Users/aramos/Documents/Hitachi/REPOS/R2D2-DEV/CatalogTestKTR/out/CombinedCsvToTextOut.csv" );
+    outputTarget.setPath(
+      "/Users/aramos/Documents/Hitachi/REPOS/R2D2-DEV/CatalogTestKTR/out/CombinedCsvToTextOut.csv" );
     List<String> outputFields = Arrays.asList( "GIVEN", "HOST", "SUR", "SPAN", "USERNAME", "LONG_LEGAL", "SSN", "SEX" );
     outputTarget.setFields( outputFields );
     addRelationship( personCsv, outputTarget, "first_name", "GIVEN" );
@@ -82,7 +97,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
     addRelationship( personDetailsCsv, outputTarget, "email", "USERNAME" );
     addRelationship( personDetailsCsv, outputTarget, "gender", "SEX" );
 
-    Mockito.verify( mockCatalogLineageClient ).processLineage( inputSourceCaptor.capture(), outputSourcesCaptor.capture() );
+    Mockito.verify( mockCatalogLineageClient ).processLineage( inputSourceCaptor.capture(), outputSourcesCaptor
+      .capture() );
     List<LineageDataResource> inputSources = inputSourceCaptor.getValue();
     assertNotNull( "input sources must not be null", inputSources );
     listContainsExpectedResource( personCsv, inputSources );
@@ -95,7 +111,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
   private void listContainsExpectedResource( LineageDataResource resource, List<LineageDataResource> sourceList ) {
     sourceList.forEach( this::cleanVertexIds );
     assertTrue( String.format( "did not find %s resource", resource.getName() ), sourceList.contains( resource ) );
-    List<FieldLevelRelationship> personCsvRelationshipsComputed = sourceList.stream().filter( r -> r.getName().equals( resource.getName() ) ).findFirst().get()
+    List<FieldLevelRelationship> personCsvRelationshipsComputed = sourceList.stream().filter( r -> r.getName().equals(
+        resource.getName() ) ).findFirst().get()
       .getFieldLevelRelationships();
     assertTrue( String.format( "field relationships in %s resource incorrect", resource.getName() ),
       personCsvRelationshipsComputed.containsAll( resource.getFieldLevelRelationships() )
@@ -130,7 +147,7 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
 
     graphCatalogWriter.outputGraphImpl( graph, null );
 
-    Path personCsvPath = Paths.get("src", "it", "resources", "person.csv");
+    Path personCsvPath = Paths.get( "src", "it", "resources", "person.csv" );
     LineageDataResource personCsv = new LineageDataResource( "person.csv" );
     personCsv.setPath( personCsvPath.toAbsolutePath().toString() );
     List<String> personFields = Arrays.asList( "first_name", "id", "last_name" );
@@ -146,7 +163,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
     addRelationship( personCsv, outputTarget, "last_name", "NAME2" );
     addRelationship( personCsv, outputTarget, "id", "SSN" );
 
-    Mockito.verify( mockCatalogLineageClient ).processLineage( inputSourceCaptor.capture(), outputSourcesCaptor.capture() );
+    Mockito.verify( mockCatalogLineageClient ).processLineage( inputSourceCaptor.capture(), outputSourcesCaptor
+      .capture() );
     List<LineageDataResource> inputSources = inputSourceCaptor.getValue();
     listContainsExpectedResource( personCsv, inputSources );
     List<LineageDataResource> outputSources = outputSourcesCaptor.getValue();
@@ -154,7 +172,8 @@ public class GraphCatalogWriterIT extends StepAnalyzerValidationIT {
     listContainsExpectedResource( outputTarget, outputSources );
   }
 
-  private void addRelationship( LineageDataResource input, LineageDataResource output, String inputField, String outputField ) {
+  private void addRelationship( LineageDataResource input, LineageDataResource output, String inputField,
+                                String outputField ) {
     FieldLevelRelationship r1 = new FieldLevelRelationship();
     r1.setInputSourceResource( input );
     r1.setOutputTargetResource( output );

--- a/core/src/it/java/org/pentaho/metaverse/impl/MetaverseBuilderIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/impl/MetaverseBuilderIT.java
@@ -72,6 +72,9 @@ public class MetaverseBuilderIT {
 
   @AfterClass
   public static void cleanUp() throws Exception {
+    // drain async lineage analysis before tearing down PentahoSystem; otherwise worker threads
+    // keep analyzing against a torn-down system and can race export readers in the same fork JVM
+    org.pentaho.metaverse.graph.LineageGraphCompletionService.getInstance().waitTillEmpty();
     IntegrationTestUtil.shutdownPentahoSystem();
   }
 

--- a/core/src/it/java/org/pentaho/metaverse/step/MappingAnalyzerValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/MappingAnalyzerValidationIT.java
@@ -11,20 +11,14 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
 import org.pentaho.metaverse.frames.TransformationNode;
 import org.pentaho.metaverse.frames.TransformationStepNode;
-import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,11 +26,28 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.pentaho.dictionary.DictionaryConst.*;
+import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_TRANS;
+import static org.pentaho.dictionary.DictionaryConst.NODE_TYPE_TRANS_FIELD;
+import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS;
+import static org.pentaho.dictionary.DictionaryConst.LINK_TYPE_CONCEPT;
+import static org.pentaho.dictionary.DictionaryConst.LINK_EXECUTES;
+import static org.pentaho.dictionary.DictionaryConst.LINK_INPUTS;
+import static org.pentaho.dictionary.DictionaryConst.LINK_OUTPUTS;
+import static org.pentaho.dictionary.DictionaryConst.LINK_DERIVES;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_STEP_TYPE;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_PLUGIN_ID;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_TYPE;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_ANALYZER;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_CATEGORY;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_COPIES;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_LOGICAL_ID;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_NAME;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_NAMESPACE;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_PATH;
+import static org.pentaho.dictionary.DictionaryConst.PROPERTY_VERBOSE_DETAILS;
+import static org.pentaho.dictionary.DictionaryConst.NODE_VIRTUAL;
+import static org.pentaho.dictionary.DictionaryConst.LINK_HOPSTO;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
 
   private static final String VALUE = "value";
@@ -69,7 +80,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     // verify individual step nodes
     final Map<String, FramedMetaverseNode> parentStepNodeMap = verifyTransformationSteps( transformationNode,
       new String[] { "Data grid", "Write to log - Data grid", "mapping - calc checksum",
-        "Write to log - mapping - calc checksum", "Write to log Checksum" },  false );
+        "Write to log - mapping - calc checksum", "Write to log Checksum" }, false );
 
     final Map<String, FramedMetaverseNode> subTransStepNodeMap = verifyTransformationSteps( subTransNode,
       new String[] { "Input checksum", "calc checksum", "output checksum", "Write to log - Input checksum",
@@ -158,7 +169,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     verifyNodes( IteratorUtils.toList( outputChecksum.getPreviousSteps().iterator() ), testStepNode(
       calcChecksumSubTrans.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getNextSteps().iterator() ),
-      testStepNode(  writeToLogOutputChecksum.getName() ) );
+      testStepNode( writeToLogOutputChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getInputStreamFields().iterator() ),
       testFieldNode( CHECKSUM ), testFieldNode( VALUE ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getOutputStreamFields().iterator() ),
@@ -214,8 +225,9 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
 
     assertEquals( writeToLogChecksum,
       verifyLinkedNode( outputChecksum_output_checksum, LINK_INPUTS, writeToLogChecksum.getName() ) );
-    assertEquals( writeToLogChecksum_output_newChecksum, verifyLinkedNode( outputChecksum_output_checksum,
-      LINK_DERIVES, NEW_CHECKSUM ) );
+    // Several newChecksum derives targets may exist; assert membership, not unordered edge iteration.
+    assertTrue( IteratorUtils.toList( outputChecksum_output_checksum.getOutNodes( LINK_DERIVES ).iterator() )
+      .contains( writeToLogChecksum_output_newChecksum ) );
   }
 
   @Test
@@ -240,7 +252,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     // verify individual step nodes
     final Map<String, FramedMetaverseNode> parentStepNodeMap = verifyTransformationSteps( transformationNode,
       new String[] { "Data grid", "Write to log - Data grid", "mapping - calc checksum",
-        "Write to log - mapping - calc checksum", "Write to log Checksum" },  false );
+        "Write to log - mapping - calc checksum", "Write to log Checksum" }, false );
 
     final Map<String, FramedMetaverseNode> subTransStepNodeMap = verifyTransformationSteps( subTransNode,
       new String[] { "Input checksum", "calc checksum", "output checksum", "Write to log - Input checksum",
@@ -328,7 +340,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     verifyNodes( IteratorUtils.toList( outputChecksum.getPreviousSteps().iterator() ), testStepNode(
       calcChecksumSubTrans.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getNextSteps().iterator() ),
-      testStepNode(  writeToLogOutputChecksum.getName() ) );
+      testStepNode( writeToLogOutputChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getInputStreamFields().iterator() ),
       testFieldNode( CHECKSUM ), testFieldNode( VALUE ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getOutputStreamFields().iterator() ),
@@ -384,8 +396,9 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
 
     assertEquals( writeToLogChecksum,
       verifyLinkedNode( outputChecksum_output_checksum, LINK_INPUTS, writeToLogChecksum.getName() ) );
-    assertEquals( writeToLogChecksum_output_newChecksum, verifyLinkedNode( outputChecksum_output_checksum,
-      LINK_DERIVES, NEW_CHECKSUM ) );
+    // Several newChecksum derives targets may exist; assert membership, not unordered edge iteration.
+    assertTrue( IteratorUtils.toList( outputChecksum_output_checksum.getOutNodes( LINK_DERIVES ).iterator() )
+      .contains( writeToLogChecksum_output_newChecksum ) );
   }
 
   @Test
@@ -412,8 +425,8 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
         "Write to log - mapping - calc checksum" }, false );
 
     final Map<String, FramedMetaverseNode> subTransStepNodeMap = verifyTransformationSteps( subTransNode,
-      new String[] { "Input checksum", "calc checksum", "output checksum" , "Write to log - Input checksum",
-        "Write to log - calc checksum", "Write to log - output checksum"}, false );
+      new String[] { "Input checksum", "calc checksum", "output checksum", "Write to log - Input checksum",
+        "Write to log - calc checksum", "Write to log - output checksum" }, false );
 
     final TransformationStepNode dataGrid = (TransformationStepNode) parentStepNodeMap.get(
       "Data grid" );
@@ -437,7 +450,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     // ---------- Data grid
     verifyNodes( IteratorUtils.toList( dataGrid.getPreviousSteps().iterator() ) );
     verifyNodes( IteratorUtils.toList( dataGrid.getNextSteps().iterator() ), testLineageNode( calcChecksum ),
-      testLineageNode( writeToLogDataGrid ));
+      testLineageNode( writeToLogDataGrid ) );
     verifyNodes( IteratorUtils.toList( dataGrid.getOutputStreamFields().iterator() ),
       testFieldNode( VALUE ) );
     assertEquals( 2, getIterableSize( dataGrid.getAllInNodes() ) );
@@ -469,7 +482,8 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
       .put( PROPERTY_ANALYZER, SKIP ).put( PROPERTY_CATEGORY, SKIP ).put( PROPERTY_COPIES, SKIP )
       .put( PROPERTY_LOGICAL_ID, SKIP ).put( PROPERTY_NAME, SKIP ).put( PROPERTY_NAMESPACE, SKIP )
       .put( PROPERTY_PATH, SKIP ).put( NODE_VIRTUAL, SKIP ).put( "subTransformation", SKIP )
-      .put( PROPERTY_VERBOSE_DETAILS, "input [1],input [1] update field names,output [1],output [1] update field names" )
+      .put( PROPERTY_VERBOSE_DETAILS,
+        "input [1],input [1] update field names,output [1],output [1] update field names" )
       .put( "input [1]", "Data grid > [sub] Input checksum" )
       .put( "input [1] update field names", "false" )
       .put( "output [1]", "[sub] output checksum > Write to log Checksum" )
@@ -495,7 +509,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     verifyNodes( IteratorUtils.toList( outputChecksum.getPreviousSteps().iterator() ),
       testStepNode( calcChecksumSubTrans.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getNextSteps().iterator() ),
-      testStepNode( writeToLogOutputChecksum.getName() ));
+      testStepNode( writeToLogOutputChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getInputStreamFields().iterator() ),
       testFieldNode( CHECKSUM ), testFieldNode( VALUE ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getOutputStreamFields().iterator() ),
@@ -577,8 +591,8 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
         "Write to log - mapping - calc checksum" }, false );
 
     final Map<String, FramedMetaverseNode> subTransStepNodeMap = verifyTransformationSteps( subTransNode,
-      new String[] { "Input checksum", "calc checksum", "output checksum" , "Write to log - Input checksum",
-        "Write to log - calc checksum", "Write to log - output checksum"}, false );
+      new String[] { "Input checksum", "calc checksum", "output checksum", "Write to log - Input checksum",
+        "Write to log - calc checksum", "Write to log - output checksum" }, false );
 
     final TransformationStepNode dataGrid = (TransformationStepNode) parentStepNodeMap.get(
       "Data grid" );
@@ -602,7 +616,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     // ---------- Data grid
     verifyNodes( IteratorUtils.toList( dataGrid.getPreviousSteps().iterator() ) );
     verifyNodes( IteratorUtils.toList( dataGrid.getNextSteps().iterator() ), testLineageNode( calcChecksum ),
-      testLineageNode( writeToLogDataGrid ));
+      testLineageNode( writeToLogDataGrid ) );
     verifyNodes( IteratorUtils.toList( dataGrid.getOutputStreamFields().iterator() ),
       testFieldNode( VALUE ) );
     assertEquals( 2, getIterableSize( dataGrid.getAllInNodes() ) );
@@ -660,7 +674,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     verifyNodes( IteratorUtils.toList( outputChecksum.getPreviousSteps().iterator() ),
       testStepNode( calcChecksumSubTrans.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getNextSteps().iterator() ),
-      testStepNode( writeToLogOutputChecksum.getName() ));
+      testStepNode( writeToLogOutputChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getInputStreamFields().iterator() ),
       testFieldNode( CHECKSUM ), testFieldNode( VALUE ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getOutputStreamFields().iterator() ),
@@ -739,7 +753,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
 
     // verify individual step nodes
     final Map<String, FramedMetaverseNode> parentStepNodeMap = verifyTransformationSteps( transformationNode,
-      new String[] { "Data grid", "calc parity & checksum",  "Write to log Checksum", "Write to log Parity",
+      new String[] { "Data grid", "calc parity & checksum", "Write to log Checksum", "Write to log Parity",
         "Write to log Dummy", "Write to log - Data grid" }, false );
 
     final Map<String, FramedMetaverseNode> subTransStepNodeMap = verifyTransformationSteps( subTransNode,
@@ -826,7 +840,7 @@ public class MappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
     verifyNodes( IteratorUtils.toList( outputChecksum.getPreviousSteps().iterator() ),
       testStepNode( calcChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getNextSteps().iterator() ),
-      testStepNode( writeToLogOutputChecksum.getName()  ) );
+      testStepNode( writeToLogOutputChecksum.getName() ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getInputStreamFields().iterator() ),
       testFieldNode( CHECKSUM ), testFieldNode( VALUE ) );
     verifyNodes( IteratorUtils.toList( outputChecksum.getOutputStreamFields().iterator() ),

--- a/core/src/it/java/org/pentaho/metaverse/step/MdiValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/MdiValidationIT.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
 import com.google.common.collect.ImmutableMap;
@@ -19,16 +18,11 @@ import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.pentaho.metaverse.frames.FileNode;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
 import org.pentaho.metaverse.frames.StreamFieldNode;
 import org.pentaho.metaverse.frames.TransformationNode;
 import org.pentaho.metaverse.frames.TransformationStepNode;
-import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,9 +32,6 @@ import java.util.Map;
 import static org.junit.Assert.*;
 import static org.pentaho.dictionary.DictionaryConst.*;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 // TODO: Ignored for now, remove the @Ignore annotation once https://jira.pentaho.com/browse/ENGOPS-4612 is resolved
 @Ignore
 public class MdiValidationIT extends StepAnalyzerValidationIT {
@@ -118,8 +109,8 @@ public class MdiValidationIT extends StepAnalyzerValidationIT {
     final List<StreamFieldNode> inputFields = IteratorUtils.toList(
       textFileOutputNode.getInputStreamFields().iterator() );
     assertEquals( mdiOutputFields.size(), inputFields.size() );
-    final List<StreamFieldNode> tempalteReadFromStepOutputFields = templateReadFromStepNode == null
-      ? new ArrayList() : IteratorUtils.toList( templateReadFromStepNode.getOutputStreamFields().iterator() );
+    final List<StreamFieldNode> templateReadFromStepOutputFields = templateReadFromStepNode == null ? new ArrayList() :
+      IteratorUtils.toList( templateReadFromStepNode.getOutputStreamFields().iterator() );
 
     for ( final StreamFieldNode field : inputFields ) {
       assertTrue( mdiOutputFields.contains( field ) );
@@ -132,7 +123,7 @@ public class MdiValidationIT extends StepAnalyzerValidationIT {
         final StreamFieldNode derivingField = (StreamFieldNode) IteratorUtils.toList(
           field.getFieldNodesThatDeriveMe().iterator() ).get( 0 );
         assertTrue( mdiInputFields.contains( derivingField ) );
-        assertTrue( tempalteReadFromStepOutputFields.contains( derivingField ) );
+        assertTrue( templateReadFromStepOutputFields.contains( derivingField ) );
         assertEquals( field.getName(), derivingField.getName() );
       }
     }
@@ -457,8 +448,10 @@ public class MdiValidationIT extends StepAnalyzerValidationIT {
       .put( "streamTargetStepname", SKIP ).put( "streamSourceStepname", SKIP ).put( "targetFile", SKIP )
       .put( "sourceStepName", SKIP )
       .put( PROPERTY_VERBOSE_DETAILS, "mapping [1],ignored mapping [1],mapping [2],ignored mapping [2]" )
-      .put( "mapping [1]", "Text Output: Separator > [template_stream_different_than_mapping] My Text file output: SEPARATOR" )
-      .put( "mapping [2]", "Text Output: File Name > [template_stream_different_than_mapping] My Text file output: FILENAME" )
+      .put( "mapping [1]",
+        "Text Output: Separator > [template_stream_different_than_mapping] My Text file output: SEPARATOR" )
+      .put( "mapping [2]",
+        "Text Output: File Name > [template_stream_different_than_mapping] My Text file output: FILENAME" )
       .put( "ignored mapping [1]", "Text Output - Fields: Trim Type > [template_stream_different_than_mapping]"
         + " My Text file output: OUTPUT_TRIM" )
       .put( "ignored mapping [2]", "Text Output - Fields: Field Name > [template_stream_different_than_mapping]"

--- a/core/src/it/java/org/pentaho/metaverse/step/SimpleMappingAnalyzerValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/SimpleMappingAnalyzerValidationIT.java
@@ -11,20 +11,14 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
 import org.pentaho.metaverse.frames.TransformationNode;
 import org.pentaho.metaverse.frames.TransformationStepNode;
-import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -32,9 +26,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.pentaho.dictionary.DictionaryConst.*;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 public class SimpleMappingAnalyzerValidationIT extends StepAnalyzerValidationIT {
 
   private static final String VALUE = "value";
@@ -111,8 +102,9 @@ public class SimpleMappingAnalyzerValidationIT extends StepAnalyzerValidationIT 
       .put( PROPERTY_ANALYZER, SKIP ).put( PROPERTY_CATEGORY, SKIP ).put( PROPERTY_COPIES, SKIP )
       .put( PROPERTY_LOGICAL_ID, SKIP ).put( PROPERTY_NAME, SKIP ).put( PROPERTY_NAMESPACE, SKIP )
       .put( PROPERTY_PATH, SKIP ).put( NODE_VIRTUAL, SKIP ).put( "subTransformation", SKIP )
-      .put( PROPERTY_VERBOSE_DETAILS, "input [1],input [1] update field names,input [1] rename [1],output [1],output [1] "
-        + "update field names,output [1] rename [1]" )
+      .put( PROPERTY_VERBOSE_DETAILS,
+        "input [1],input [1] update field names,input [1] rename [1],output [1],output [1] "
+          + "update field names,output [1] rename [1]" )
       .put( "input [1]", "Generate random integer > [simple_sub] Input parity" )
       .put( "input [1] update field names", "true" )
       .put( "input [1] rename [1]", "randomValue > value" )

--- a/core/src/it/java/org/pentaho/metaverse/step/SingleThreaderStepAnalyzerValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/SingleThreaderStepAnalyzerValidationIT.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
 import com.google.common.collect.ImmutableMap;
@@ -77,7 +76,8 @@ public class SingleThreaderStepAnalyzerValidationIT extends StepAnalyzerValidati
       "Mapping output specification" );
 
     // ---------- Generate Random Int
-    verifyNodes( IteratorUtils.toList( singleThreader.getPreviousSteps().iterator() ), testStepNode( "Add constants" ) );
+    verifyNodes( IteratorUtils.toList( singleThreader.getPreviousSteps().iterator() ), testStepNode(
+      "Add constants" ) );
     verifyNodes( IteratorUtils.toList( singleThreader.getNextSteps().iterator() ),
       testStepNode( writeToLog.getName() ), testStepNode( writeToLog2.getName() ) );
     verifyNodes( IteratorUtils.toList( singleThreader.getInputStreamFields().iterator() ),
@@ -99,13 +99,17 @@ public class SingleThreaderStepAnalyzerValidationIT extends StepAnalyzerValidati
     final FramedMetaverseNode stringOperations_output_counter = verifyLinkedNode( stringOperations, LINK_OUTPUTS,
       "counter" );
     final FramedMetaverseNode outputSpec_output_counter = verifyLinkedNode( outputSpec, LINK_OUTPUTS, "counter" );
-    assertEquals( inputSpec_output_counter,
-      verifyLinkedNode( singleThreader_output_counter, LINK_DERIVES, "counter" ) );
+    // several "counter" derives targets may exist per node; assert membership, not iteration order
+    // (TinkerGraph vertex iteration order is not insertion order since the tinkerpop 3 migration)
+    org.junit.Assert.assertTrue(
+      verifyLinkedNodes( singleThreader_output_counter, LINK_DERIVES, "counter" ).contains(
+        inputSpec_output_counter ) );
     assertEquals( stringOperations_output_counter,
       verifyLinkedNode( inputSpec_output_counter, LINK_DERIVES, "counter" ) );
     assertEquals( outputSpec_output_counter,
       verifyLinkedNode( stringOperations_output_counter, LINK_DERIVES, "counter" ) );
-    assertEquals( singleThreader_output_counter,
-      verifyLinkedNode( outputSpec_output_counter, LINK_DERIVES, "counter" ) );
+    org.junit.Assert.assertTrue(
+      verifyLinkedNodes( outputSpec_output_counter, LINK_DERIVES, "counter" ).contains(
+        singleThreader_output_counter ) );
   }
 }

--- a/core/src/it/java/org/pentaho/metaverse/step/StepAnalyzerValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/StepAnalyzerValidationIT.java
@@ -11,34 +11,37 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
+import org.junit.After;
 import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.pentaho.metaverse.BaseMetaverseValidationIT;
 import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 public abstract class StepAnalyzerValidationIT extends BaseMetaverseValidationIT {
+
+  private MockedStatic<MetaverseConfig> metaverseConfigMock;
 
   @Before
   public void init() throws Exception {
 
-    PowerMockito.mockStatic( MetaverseConfig.class );
-    Mockito.when( MetaverseConfig.adjustExternalResourceFields() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.deduplicateTransformationFields() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.consolidateSubGraphs() ).thenReturn( true );
-    Mockito.when( MetaverseConfig.generateSubGraphs() ).thenReturn( true );
+    metaverseConfigMock = Mockito.mockStatic( MetaverseConfig.class, Mockito.CALLS_REAL_METHODS );
+    metaverseConfigMock.when( MetaverseConfig::adjustExternalResourceFields ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::deduplicateTransformationFields ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::consolidateSubGraphs ).thenReturn( true );
+    metaverseConfigMock.when( MetaverseConfig::generateSubGraphs ).thenReturn( true );
 
+  }
+
+  @After
+  public void tearDownMock() {
+    if ( metaverseConfigMock != null ) {
+      metaverseConfigMock.close();
+      metaverseConfigMock = null;
+    }
   }
 
   @Override
@@ -48,11 +51,11 @@ public abstract class StepAnalyzerValidationIT extends BaseMetaverseValidationIT
 
   protected void initTest( final String transNodeName ) throws Exception {
     BaseMetaverseValidationIT.init( getRootFolder() + "/" + transNodeName,
-      getOutputFileRoot() + "/" + transNodeName + ".graphml");
+      getOutputFileRoot() + "/" + transNodeName + ".graphml" );
   }
 
   protected String getRootFolder() {
-    return  "src/it/resources/repo/" + getClass().getSimpleName();
+    return "src/it/resources/repo/" + getClass().getSimpleName();
   }
 
   protected String getOutputFileRoot() {

--- a/core/src/it/java/org/pentaho/metaverse/step/TableOutputValidationIT.java
+++ b/core/src/it/java/org/pentaho/metaverse/step/TableOutputValidationIT.java
@@ -11,22 +11,16 @@
  ******************************************************************************/
 
 
-
 package org.pentaho.metaverse.step;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.pentaho.metaverse.frames.DatasourceNode;
 import org.pentaho.metaverse.frames.FramedMetaverseNode;
 import org.pentaho.metaverse.frames.TransformationNode;
 import org.pentaho.metaverse.frames.TransformationStepNode;
-import org.pentaho.metaverse.impl.MetaverseConfig;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,9 +30,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.pentaho.dictionary.DictionaryConst.*;
 
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( "jdk.internal.reflect.*" )
-@PrepareForTest( MetaverseConfig.class )
 // TODO: Ignore the test for now, as it will not run succesfully on a node that does not have the required DB configured
 @Ignore
 public class TableOutputValidationIT extends StepAnalyzerValidationIT {

--- a/core/src/it/resources/solution/system/pentahoObjects.spring.xml
+++ b/core/src/it/resources/solution/system/pentahoObjects.spring.xml
@@ -2,9 +2,12 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd"
        default-lazy-init="true">
 
-  <!-- Configure our graph using the SynchronizedGraphFactory and a configuration file -->
+  <!-- Configure our graph using the SynchronizedGraphFactory; the configuration is ignored,
+       a new TinkerGraph is always opened (see SynchronizedGraphFactory.open) -->
   <bean id="MetaverseGraphImpl" class="org.pentaho.metaverse.graph.SynchronizedGraphFactory" factory-method="open">
-    <constructor-arg value="src/it/resources/graph.properties"/>
+    <constructor-arg>
+      <map/>
+    </constructor-arg>
   </bean>
 
   <bean id="IMetaverseBuilder" class="org.pentaho.metaverse.impl.MetaverseBuilder" scope="singleton">


### PR DESCRIPTION
**IMPORTANT**: To be merged only after [this PR](https://github.com/pentaho/pentaho-metaverse/pull/749) is merged. Rebase is then needed.

This PR aims to solve ITs not being executed on the pipeline and with the following summary on the issues:

- The build was broken before any ITs even ran due to a generic type inference issue (left over from the June migration to tinkerpop 3). Fixed by adding a small explicit type hint in the test frame;

- Every IT would crash instantly with a class-file corruption error due to usage of PowerMock (library abandoned in 2020 that rewrites classes with a 2015 version of Javassist) which cannot handle Java 17 class files. Removed all PowerMock usage in affected tests/module and replaced with Mockito's built-in static mocking (mockito-inline 5.2.0 was already a on classpath). This also resolved a version clash with Mockito that was failing next;

- Stale test fixture where a Spring bean definition still called a factory method that the June migration had deleted. The bean now passed the empty map the new API expects;

- A graph-traversal porting issue from the same migration where the old "loop-until-match" queries were rewritten in a way that no longer filtered results, so one query exploded from a handful of nodes to over 76,000. Rewrite of the affected traversals with reviewed stop-and-filter semantics.

- Some ITs needed a JNDI datasource named SampleData that was never defined and thus, a basic `jdbc.properties` was added and the bundled H2 database was recreated in the current H2 2.x format (the old file was unreadable by the driver now in use);

- The Rest step plugin was not available to the tests because Kettle only discovers annotated plugins from a plugins folder,
so the build now stages the plugin jar there;

- Two tests compared random graph-vertex IDs in an order that the new graph library does not guarantee, so those assertions now check membership instead of order;

Points addressed in its proper Jira/[PR](https://github.com/pentaho/pentaho-metaverse/pull/749) combo: 

- A bug on the transformation and job analyzers that initialized their analyzer providers through a bare singleton that is empty outside the OSGi runtime, so every step was handled by a do-nothing generic analyzer. With that, the lineage graph never got its `uses`, `derives`, or `joins` links in standalone execution and a regression test, that fails without the fix and passes with it, was added;

- The lineage client origin walk treated `joins` links as terminal paths, truncating merge-join lineage. The fix restores behavior covered by existing 2015 expectations and the LineageClientIT and full IT suite pass;

- The lineage analysis background tasks were allowed to outlive their test class and corrupt the next test in the shared test JVM, so the tests now drain the task queue before teardown.

This also brings back some "temporarily deleted" `LineageClientTest` unit tests removed in 2015 (8 tests restored) and the `AnnotationDrivenStepMetaAnalyzerTest` unit tests commented out in 2022 because of a hang caused by PowerMock (7 tests restored all ok).