### PR TITLE
test: drop unneeded rest-core plugin dependency [BACKLOG-43745]

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -234,12 +234,6 @@
       <version>${dependency.org.mockito.mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>rest-core</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
     <!-- TODO: uncomment once https://jira.pentaho.com/browse/ENGOPS-4612 is resolved -->
     <!--
     <dependency>
@@ -282,33 +276,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>stage-rest-plugin-for-its</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.pentaho.di.plugins</groupId>
-                  <artifactId>rest-core</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-              </artifactItems>
-              <!-- KettleEnvironment.init() scans KETTLE_PLUGIN_BASE_FOLDERS (target/spoon/plugins,
-                   see IntegrationTestUtil) for @Step-annotated plugin jars -->
-              <outputDirectory>${project.build.directory}/spoon/plugins/rest-core</outputDirectory>
-              <overWriteIfNewer>true</overWriteIfNewer>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${maven-pmd-plugin.version}</version>


### PR DESCRIPTION
The addition of the dependency was a defensive strategy when leveraging AI to help dealing with BACKLOG-43745.

Why it isn't actually needed:

`rest-core` dependency was added during BACKLOG-43745 IT repair to load `rest_client.ktr` which ended up creating an invalid release dependency as `rest-core` is produced later in PDI pipeline, so its release artifact may not exist when Metaverse builds.

Core no longer owns REST analysis as it moved to PDI `rest-core` in 2023 (448d0dd10924cfdf6b189553523d52702a0555d9), along with removed dedicated Metaverse REST tests (6b65e8951a1a1c7f0837790b34873ab572ce3152).